### PR TITLE
fix: ignore permissions on docshare on owner change

### DIFF
--- a/next_crm/overrides/lead.py
+++ b/next_crm/overrides/lead.py
@@ -86,7 +86,7 @@ class Lead(Lead):
                     flags={"ignore_share_permission": True},
                 )
             elif user != agent:
-                frappe.share.remove(self.doctype, self.name, user)
+                frappe.delete_doc("DocShare", self.name, ignore_permissions=True)
 
     def create_contact(self, throw=False):
         if not self.lead_name:

--- a/next_crm/overrides/opportunity.py
+++ b/next_crm/overrides/opportunity.py
@@ -128,7 +128,7 @@ class Opportunity(Opportunity):
                     flags={"ignore_share_permission": True},
                 )
             elif user != agent:
-                frappe.share.remove(self.doctype, self.name, user)
+                frappe.delete_doc("DocShare", self.name, ignore_permissions=True)
 
     def set_sla(self):
         """


### PR DESCRIPTION
DocShare doesn't allow removal apart from `System Manager`.
We need to override this to allow changing opportunity owners in system.
Hence, we can use `ignore_permissions` to bypass it.