### PR TITLE
Sort activities by creation date and remove auto scroll

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -10,10 +10,7 @@
     :whatsappBox="whatsappBox"
     :modalRef="modalRef"
   />
-  <FadedScrollableDiv
-    :maskHeight="30"
-    class="flex flex-col flex-1 overflow-y-auto"
-  >
+  <FadedScrollableDiv :maskHeight="30" class="flex flex-col flex-1 overflow-y-auto">
     <div
       v-if="all_activities?.loading"
       class="flex flex-1 flex-col items-center justify-center gap-3 text-xl font-medium text-ink-gray-4"
@@ -21,13 +18,7 @@
       <LoadingIndicator class="h-6 w-6" />
       <span>{{ __('Loading...') }}</span>
     </div>
-    <div
-      v-else-if="
-        activities?.length ||
-        (whatsappMessages.data?.length && title == 'WhatsApp')
-      "
-      class="activities"
-    >
+    <div v-else-if="activities?.length || (whatsappMessages.data?.length && title == 'WhatsApp')" class="activities">
       <div v-if="title == 'WhatsApp' && whatsappMessages.data?.length">
         <WhatsAppArea
           class="px-3 sm:px-10"
@@ -46,16 +37,12 @@
       </div>
       <div v-else-if="title == 'Comments'" class="pb-5">
         <div v-for="(comment, i) in activities">
-          <div
-            class="activity grid grid-cols-[30px_minmax(auto,_1fr)] gap-2 px-3 sm:gap-4 sm:px-10"
-          >
+          <div class="activity grid grid-cols-[30px_minmax(auto,_1fr)] gap-2 px-3 sm:gap-4 sm:px-10">
             <div
               class="relative flex justify-center after:absolute after:left-[50%] after:top-0 after:-z-10 after:border-l after:border-gray-200"
               :class="i != activities.length - 1 ? 'after:h-full' : 'after:h-4'"
             >
-              <div
-                class="z-10 flex h-8 w-7 items-center justify-center bg-surface-white"
-              >
+              <div class="z-10 flex h-8 w-7 items-center justify-center bg-surface-white">
                 <CommentIcon class="text-ink-gray-8" />
               </div>
             </div>
@@ -68,51 +55,29 @@
       </div>
       <div v-else-if="title == 'Calls'" class="activity">
         <div v-for="(call, i) in activities">
-          <div
-            class="activity grid grid-cols-[30px_minmax(auto,_1fr)] gap-4 px-3 sm:px-10"
-          >
+          <div class="activity grid grid-cols-[30px_minmax(auto,_1fr)] gap-4 px-3 sm:px-10">
             <div
               class="relative flex justify-center after:absolute after:left-[50%] after:top-0 after:-z-10 after:border-l after:border-gray-200"
               :class="i != activities.length - 1 ? 'after:h-full' : 'after:h-4'"
             >
-              <div
-                class="z-10 flex h-8 w-7 items-center justify-center bg-surface-white text-ink-gray-8"
-              >
-                <MissedCallIcon
-                  v-if="call.status == 'No Answer'"
-                  class="text-ink-red-4"
-                />
+              <div class="z-10 flex h-8 w-7 items-center justify-center bg-surface-white text-ink-gray-8">
+                <MissedCallIcon v-if="call.status == 'No Answer'" class="text-ink-red-4" />
                 <DeclinedCallIcon v-else-if="call.status == 'Busy'" />
-                <component
-                  v-else
-                  :is="
-                    call.type == 'Incoming' ? InboundCallIcon : OutboundCallIcon
-                  "
-                />
+                <component v-else :is="call.type == 'Incoming' ? InboundCallIcon : OutboundCallIcon" />
               </div>
             </div>
             <CallArea class="mb-4" :activity="call" />
           </div>
         </div>
       </div>
-      <div
-        v-else-if="title == 'Attachments'"
-        class="px-3 pb-3 sm:px-10 sm:pb-5"
-      >
-        <AttachmentArea
-          :attachments="activities"
-          @reload="all_activities.reload() && scroll()"
-        />
+      <div v-else-if="title == 'Attachments'" class="px-3 pb-3 sm:px-10 sm:pb-5">
+        <AttachmentArea :attachments="activities" @reload="all_activities.reload()" />
       </div>
       <div
         v-else
         v-for="(activity, i) in activities"
         class="activity px-3 sm:px-10"
-        :class="
-          ['Activity', 'Emails'].includes(title)
-            ? 'grid grid-cols-[30px_minmax(auto,_1fr)] gap-2 sm:gap-4'
-            : ''
-        "
+        :class="['Activity', 'Emails'].includes(title) ? 'grid grid-cols-[30px_minmax(auto,_1fr)] gap-2 sm:gap-4' : ''"
       >
         <div
           v-if="['Activity', 'Emails'].includes(title)"
@@ -123,59 +88,35 @@
             class="z-10 flex h-7 w-7 items-center justify-center bg-surface-white"
             :class="{
               'mt-2.5': ['communication'].includes(activity.activity_type),
-              'bg-surface-white': ['added', 'removed', 'changed'].includes(
-                activity.activity_type,
-              ),
-              'h-8': [
-                'comment',
-                'communication',
-                'incoming_call',
-                'outgoing_call',
-              ].includes(activity.activity_type),
+              'bg-surface-white': ['added', 'removed', 'changed'].includes(activity.activity_type),
+              'h-8': ['comment', 'communication', 'incoming_call', 'outgoing_call'].includes(activity.activity_type),
             }"
           >
-            <UserAvatar
-              v-if="activity.activity_type == 'communication'"
-              :user="activity.data.sender"
-              size="md"
-            />
+            <UserAvatar v-if="activity.activity_type == 'communication'" :user="activity.data.sender" size="md" />
             <MissedCallIcon
               v-else-if="
-                ['incoming_call', 'outgoing_call'].includes(
-                  activity.activity_type,
-                ) && activity.status == 'No Answer'
+                ['incoming_call', 'outgoing_call'].includes(activity.activity_type) && activity.status == 'No Answer'
               "
               class="text-ink-red-4"
             />
             <DeclinedCallIcon
               v-else-if="
-                ['incoming_call', 'outgoing_call'].includes(
-                  activity.activity_type,
-                ) && activity.status == 'Busy'
+                ['incoming_call', 'outgoing_call'].includes(activity.activity_type) && activity.status == 'Busy'
               "
             />
             <component
               v-else
               :is="activity.icon"
               :class="
-                ['added', 'removed', 'changed'].includes(activity.activity_type)
-                  ? 'text-ink-gray-4'
-                  : 'text-ink-gray-8'
+                ['added', 'removed', 'changed'].includes(activity.activity_type) ? 'text-ink-gray-4' : 'text-ink-gray-8'
               "
             />
           </div>
         </div>
-        <div
-          v-if="activity.activity_type == 'communication'"
-          class="pb-5 mt-px"
-        >
+        <div v-if="activity.activity_type == 'communication'" class="pb-5 mt-px">
           <EmailArea :activity="activity" :emailBox="emailBox" />
         </div>
-        <div
-          class="mb-4"
-          :id="activity.name"
-          v-else-if="activity.activity_type == 'comment'"
-        >
+        <div class="mb-4" :id="activity.name" v-else-if="activity.activity_type == 'comment'">
           <CommentArea :activity="activity" />
         </div>
         <div
@@ -184,24 +125,14 @@
           v-else-if="activity.activity_type == 'attachment_log'"
         >
           <div class="flex items-center justify-stretch gap-2 text-base">
-            <div
-              class="inline-flex items-center flex-wrap gap-1.5 text-ink-gray-8 font-medium"
-            >
+            <div class="inline-flex items-center flex-wrap gap-1.5 text-ink-gray-8 font-medium">
               <span class="font-medium">{{ activity.owner_name }}</span>
               <span class="text-ink-gray-5">{{ __(activity.data.type) }}</span>
-              <a
-                v-if="activity.data.file_url"
-                :href="activity.data.file_url"
-                target="_blank"
-              >
+              <a v-if="activity.data.file_url" :href="activity.data.file_url" target="_blank">
                 <span>{{ activity.data.file_name }}</span>
               </a>
               <span v-else>{{ activity.data.file_name }}</span>
-              <FeatherIcon
-                v-if="activity.data.is_private"
-                name="lock"
-                class="size-3"
-              />
+              <FeatherIcon v-if="activity.data.is_private" name="lock" class="size-3" />
             </div>
             <div class="ml-auto whitespace-nowrap">
               <Tooltip :text="dateFormat(activity.creation, dateTooltipFormat)">
@@ -213,57 +144,35 @@
           </div>
         </div>
         <div
-          v-else-if="
-            activity.activity_type == 'incoming_call' ||
-            activity.activity_type == 'outgoing_call'
-          "
+          v-else-if="activity.activity_type == 'incoming_call' || activity.activity_type == 'outgoing_call'"
           class="mb-4"
         >
           <CallArea :activity="activity" />
         </div>
         <div v-else class="mb-4 flex flex-col gap-2 py-1.5">
           <div class="flex items-center justify-stretch gap-2 text-base">
-            <div
-              v-if="activity.other_versions"
-              class="inline-flex flex-wrap gap-1.5 text-ink-gray-8 font-medium"
-            >
+            <div v-if="activity.other_versions" class="inline-flex flex-wrap gap-1.5 text-ink-gray-8 font-medium">
               <span>{{ activity.show_others ? __('Hide') : __('Show') }}</span>
               <span> +{{ activity.other_versions.length + 1 }} </span>
               <span>{{ __('changes from') }}</span>
               <span>{{ activity.owner_name }}</span>
-              <Button
-                class="!size-4"
-                variant="ghost"
-                @click="activity.show_others = !activity.show_others"
-              >
+              <Button class="!size-4" variant="ghost" @click="activity.show_others = !activity.show_others">
                 <template #icon>
                   <SelectIcon />
                 </template>
               </Button>
             </div>
-            <div
-              v-else
-              class="inline-flex items-center flex-wrap gap-1 text-ink-gray-5"
-            >
+            <div v-else class="inline-flex items-center flex-wrap gap-1 text-ink-gray-5">
               <span class="font-medium text-ink-gray-8">
                 {{ activity.owner_name }}
               </span>
               <span v-if="activity.type">{{ __(activity.type) }}</span>
-              <span
-                v-if="activity.data.field_label"
-                class="max-w-xs truncate font-medium text-ink-gray-8"
-              >
+              <span v-if="activity.data.field_label" class="max-w-xs truncate font-medium text-ink-gray-8">
                 {{ __(activity.data.field_label) }}
               </span>
               <span v-if="activity.value">{{ __(activity.value) }}</span>
-              <span
-                v-if="activity.data.old_value"
-                class="max-w-xs font-medium text-ink-gray-8"
-              >
-                <div
-                  class="flex items-center gap-1"
-                  v-if="activity.options == 'User'"
-                >
+              <span v-if="activity.data.old_value" class="max-w-xs font-medium text-ink-gray-8">
+                <div class="flex items-center gap-1" v-if="activity.options == 'User'">
                   <UserAvatar :user="activity.data.old_value" size="xs" />
                   {{ getUser(activity.data.old_value).full_name }}
                 </div>
@@ -272,14 +181,8 @@
                 </div>
               </span>
               <span v-if="activity.to">{{ __('to') }}</span>
-              <span
-                v-if="activity.data.value"
-                class="max-w-xs font-medium text-ink-gray-8"
-              >
-                <div
-                  class="flex items-center gap-1"
-                  v-if="activity.options == 'User'"
-                >
+              <span v-if="activity.data.value" class="max-w-xs font-medium text-ink-gray-8">
+                <div class="flex items-center gap-1" v-if="activity.options == 'User'">
                   <UserAvatar :user="activity.data.value" size="xs" />
                   {{ getUser(activity.data.value).full_name }}
                 </div>
@@ -297,36 +200,21 @@
               </Tooltip>
             </div>
           </div>
-          <div
-            v-if="activity.other_versions && activity.show_others"
-            class="flex flex-col gap-0.5"
-          >
+          <div v-if="activity.other_versions && activity.show_others" class="flex flex-col gap-0.5">
             <div
               v-for="activity in [activity, ...activity.other_versions]"
               class="flex items-start justify-stretch gap-2 py-1.5 text-base"
             >
               <div class="inline-flex flex-wrap gap-1 text-ink-gray-5">
-                <span
-                  v-if="activity.data.field_label"
-                  class="max-w-xs truncate text-ink-gray-5"
-                >
+                <span v-if="activity.data.field_label" class="max-w-xs truncate text-ink-gray-5">
                   {{ __(activity.data.field_label) }}
                 </span>
-                <FeatherIcon
-                  name="arrow-right"
-                  class="mx-1 h-4 w-4 text-ink-gray-5"
-                />
+                <FeatherIcon name="arrow-right" class="mx-1 h-4 w-4 text-ink-gray-5" />
                 <span v-if="activity.type">
                   {{ startCase(__(activity.type)) }}
                 </span>
-                <span
-                  v-if="activity.data.old_value"
-                  class="max-w-xs font-medium text-ink-gray-8"
-                >
-                  <div
-                    class="flex items-center gap-1"
-                    v-if="activity.options == 'User'"
-                  >
+                <span v-if="activity.data.old_value" class="max-w-xs font-medium text-ink-gray-8">
+                  <div class="flex items-center gap-1" v-if="activity.options == 'User'">
                     <UserAvatar :user="activity.data.old_value" size="xs" />
                     {{ getUser(activity.data.old_value).full_name }}
                   </div>
@@ -335,14 +223,8 @@
                   </div>
                 </span>
                 <span v-if="activity.to">{{ __('to') }}</span>
-                <span
-                  v-if="activity.data.value"
-                  class="max-w-xs font-medium text-ink-gray-8"
-                >
-                  <div
-                    class="flex items-center gap-1"
-                    v-if="activity.options == 'User'"
-                  >
+                <span v-if="activity.data.value" class="max-w-xs font-medium text-ink-gray-8">
+                  <div class="flex items-center gap-1" v-if="activity.options == 'User'">
                     <UserAvatar :user="activity.data.value" size="xs" />
                     {{ getUser(activity.data.value).full_name }}
                   </div>
@@ -353,9 +235,7 @@
               </div>
 
               <div class="ml-auto whitespace-nowrap">
-                <Tooltip
-                  :text="dateFormat(activity.creation, dateTooltipFormat)"
-                >
+                <Tooltip :text="dateFormat(activity.creation, dateTooltipFormat)">
                   <div class="text-sm text-ink-gray-5">
                     {{ __(timeAgo(activity.creation)) }}
                   </div>
@@ -366,42 +246,15 @@
         </div>
       </div>
     </div>
-    <div
-      v-else
-      class="flex flex-1 flex-col items-center justify-center gap-3 text-xl font-medium text-ink-gray-4"
-    >
+    <div v-else class="flex flex-1 flex-col items-center justify-center gap-3 text-xl font-medium text-ink-gray-4">
       <component :is="emptyTextIcon" class="h-10 w-10" />
       <span>{{ __(emptyText) }}</span>
-      <Button
-        v-if="title == 'Calls'"
-        :label="__('Make a Call')"
-        @click="makeCall(doc.data.mobile_no)"
-      />
-      <Button
-        v-else-if="title == 'Notes'"
-        :label="__('Create Note')"
-        @click="modalRef.showNote()"
-      />
-      <Button
-        v-else-if="title == 'Emails'"
-        :label="__('New Email')"
-        @click="emailBox.show = true"
-      />
-      <Button
-        v-else-if="title == 'Comments'"
-        :label="__('New Comment')"
-        @click="emailBox.showComment = true"
-      />
-      <Button
-        v-else-if="title == 'ToDos'"
-        :label="__('Create ToDo')"
-        @click="modalRef.showToDo()"
-      />
-      <Button
-        v-else-if="title == 'Attachments'"
-        :label="__('Upload Attachment')"
-        @click="showFilesUploader = true"
-      />
+      <Button v-if="title == 'Calls'" :label="__('Make a Call')" @click="makeCall(doc.data.mobile_no)" />
+      <Button v-else-if="title == 'Notes'" :label="__('Create Note')" @click="modalRef.showNote()" />
+      <Button v-else-if="title == 'Emails'" :label="__('New Email')" @click="emailBox.show = true" />
+      <Button v-else-if="title == 'Comments'" :label="__('New Comment')" @click="emailBox.showComment = true" />
+      <Button v-else-if="title == 'ToDos'" :label="__('Create ToDo')" @click="modalRef.showToDo()" />
+      <Button v-else-if="title == 'Attachments'" :label="__('Upload Attachment')" @click="showFilesUploader = true" />
     </div>
   </FadedScrollableDiv>
   <div>
@@ -411,7 +264,6 @@
       v-model="doc"
       v-model:reload="reload_email"
       :doctype="doctype"
-      @scroll="scroll"
     />
     <WhatsAppBox
       ref="whatsappBox"
@@ -420,7 +272,6 @@
       v-model:reply="replyMessage"
       v-model:whatsapp="whatsappMessages"
       :doctype="doctype"
-      @scroll="scroll"
     />
   </div>
   <WhatsappTemplateSelectorModal
@@ -429,12 +280,7 @@
     :doctype="doctype"
     @send="(t) => sendTemplate(t)"
   />
-  <AllModals
-    ref="modalRef"
-    v-model="all_activities"
-    :doctype="doctype"
-    :doc="doc"
-  />
+  <AllModals ref="modalRef" v-model="all_activities" :doctype="doctype" :doc="doc" />
   <FilesUploader
     v-if="doc.data?.name"
     v-model="showFilesUploader"
@@ -481,13 +327,7 @@ import CommunicationArea from '@/components/CommunicationArea.vue'
 import WhatsappTemplateSelectorModal from '@/components/Modals/WhatsappTemplateSelectorModal.vue'
 import AllModals from '@/components/Activities/AllModals.vue'
 import FilesUploader from '@/components/FilesUploader/FilesUploader.vue'
-import {
-  timeAgo,
-  dateFormat,
-  dateTooltipFormat,
-  secondsToDuration,
-  startCase,
-} from '@/utils'
+import { timeAgo, dateFormat, dateTooltipFormat, secondsToDuration, startCase } from '@/utils'
 import { globalStore } from '@/stores/global'
 import { usersStore } from '@/stores/users'
 import { contactsStore } from '@/stores/contacts'
@@ -495,16 +335,7 @@ import { whatsappEnabled } from '@/composables/settings'
 import { capture } from '@/telemetry'
 import { Button, Tooltip, createResource } from 'frappe-ui'
 import { useElementVisibility } from '@vueuse/core'
-import {
-  ref,
-  computed,
-  h,
-  markRaw,
-  watch,
-  nextTick,
-  onMounted,
-  onBeforeUnmount,
-} from 'vue'
+import { ref, computed, h, markRaw, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useRoute } from 'vue-router'
 
 const { makeCall, $socket } = globalStore()
@@ -550,17 +381,12 @@ const all_activities = createResource({
     if (calls?.length) {
       calls.forEach((doc) => {
         doc.show_recording = false
-        doc.activity_type =
-          doc.type === 'Incoming' ? 'incoming_call' : 'outgoing_call'
+        doc.activity_type = doc.type === 'Incoming' ? 'incoming_call' : 'outgoing_call'
         doc.duration = secondsToDuration(doc.duration)
         if (doc.type === 'Incoming') {
           doc.caller = {
-            label:
-              getContact(doc.from)?.full_name ||
-              getLeadContact(doc.from)?.full_name ||
-              'Unknown',
-            image:
-              getContact(doc.from)?.image || getLeadContact(doc.from)?.image,
+            label: getContact(doc.from)?.full_name || getLeadContact(doc.from)?.full_name || 'Unknown',
+            image: getContact(doc.from)?.image || getLeadContact(doc.from)?.image,
           }
           doc.receiver = {
             label: getUser(doc.receiver).full_name,
@@ -572,10 +398,7 @@ const all_activities = createResource({
             image: getUser(doc.caller).user_image,
           }
           doc.receiver = {
-            label:
-              getContact(doc.to)?.full_name ||
-              getLeadContact(doc.to)?.full_name ||
-              'Unknown',
+            label: getContact(doc.to)?.full_name || getLeadContact(doc.to)?.full_name || 'Unknown',
             image: getContact(doc.to)?.image || getLeadContact(doc.to)?.image,
           }
         }
@@ -596,7 +419,6 @@ const whatsappMessages = createResource({
   },
   auto: true,
   transform: (data) => sortByCreation(data),
-  onSuccess: () => nextTick(() => scroll()),
 })
 
 onBeforeUnmount(() => {
@@ -605,19 +427,8 @@ onBeforeUnmount(() => {
 
 onMounted(() => {
   $socket.on('whatsapp_message', (data) => {
-    if (
-      data.reference_doctype === props.doctype &&
-      data.reference_name === doc.value.data.name
-    ) {
+    if (data.reference_doctype === props.doctype && data.reference_name === doc.value.data.name) {
       whatsappMessages.reload()
-    }
-  })
-
-  nextTick(() => {
-    const hash = route.hash.slice(1) || null
-    let tabNames = props.tabs?.map((tab) => tab.name)
-    if (!tabNames?.includes(hash)) {
-      scroll(hash)
     }
   })
 })
@@ -641,8 +452,7 @@ const replyMessage = ref({})
 
 function get_activities() {
   if (!all_activities.data?.versions) return []
-  if (!all_activities.data?.calls.length)
-    return all_activities.data.versions || []
+  if (!all_activities.data?.calls.length) return all_activities.data.versions || []
   return [...all_activities.data.versions, ...all_activities.data.calls]
 }
 
@@ -652,14 +462,10 @@ const activities = computed(() => {
     _activities = get_activities()
   } else if (title.value == 'Emails') {
     if (!all_activities.data?.versions) return []
-    _activities = all_activities.data.versions.filter(
-      (activity) => activity.activity_type === 'communication',
-    )
+    _activities = all_activities.data.versions.filter((activity) => activity.activity_type === 'communication')
   } else if (title.value == 'Comments') {
     if (!all_activities.data?.versions) return []
-    _activities = all_activities.data.versions.filter(
-      (activity) => activity.activity_type === 'comment',
-    )
+    _activities = all_activities.data.versions.filter((activity) => activity.activity_type === 'comment')
   } else if (title.value == 'Calls') {
     if (!all_activities.data?.calls) return []
     return sortByCreation(all_activities.data.calls)
@@ -697,7 +503,7 @@ const activities = computed(() => {
 })
 
 function sortByCreation(list) {
-  return list.sort((a, b) => new Date(a.creation) - new Date(b.creation))
+  return list.sort((a, b) => new Date(b.creation) - new Date(a.creation))
 }
 
 function update_activities_details(activity) {
@@ -799,23 +605,6 @@ watch([reload, reload_email], ([reload_value, reload_email_value]) => {
     reload_email.value = false
   }
 })
-
-function scroll(hash) {
-  if (['todos', 'notes'].includes(route.hash?.slice(1))) return
-  setTimeout(() => {
-    let el
-    if (!hash) {
-      let e = document.getElementsByClassName('activity')
-      el = e[e.length - 1]
-    } else {
-      el = document.getElementById(hash)
-    }
-    if (el && !useElementVisibility(el).value) {
-      el.scrollIntoView({ behavior: 'smooth' })
-      el.focus()
-    }
-  }, 500)
-}
 
 defineExpose({ emailBox, all_activities })
 </script>


### PR DESCRIPTION
Currently activities are sorted with oldest first and newest last with auto scroll.
The more practical solution is to disable the auto scroll and sort with newest activity at the top.