### PR TITLE
Fetch only system users in usersStore

### DIFF
--- a/next_crm/api/session.py
+++ b/next_crm/api/session.py
@@ -15,6 +15,7 @@ def get_users():
             "full_name",
             "user_type",
         ],
+        filters={"user_type": "System User"},
         order_by="full_name asc",
         distinct=True,
     ).run(as_dict=1)


### PR DESCRIPTION
In userStore we use the API `get_users()`
The API has no filters on user type, which cause significant un-needed slow down when website has many `Website User`.
As all CRM actions are supposed to be done by `System User` only, we can set a filter to avoid `Website User`.

This can lead to increase in overall performance of the system.