### PR TITLE
Add addresses list view to contacts and prospects

### DIFF
--- a/frontend/src/components/ListViews/AddressesListView.vue
+++ b/frontend/src/components/ListViews/AddressesListView.vue
@@ -1,0 +1,196 @@
+<template>
+  <ListView
+    :class="$attrs.class"
+    :columns="columns"
+    :rows="rows"
+    :options="{
+      selectable: options.selectable,
+      showTooltip: options.showTooltip,
+      resizeColumn: options.resizeColumn,
+    }"
+    row-key="name"
+  >
+    <ListHeader class="mx-3 sm:mx-5" @columnWidthUpdated="emit('columnWidthUpdated')">
+      <ListHeaderItem
+        v-for="column in columns"
+        :key="column.key"
+        :item="column"
+        @columnWidthUpdated="emit('columnWidthUpdated', column)"
+      >
+        <Button
+          v-if="column.key == '_liked_by'"
+          variant="ghosted"
+          class="!h-4"
+          :class="isLikeFilterApplied ? 'fill-red-500' : 'fill-white'"
+          @click="() => emit('applyLikeFilter')"
+        >
+          <HeartIcon class="h-4 w-4" />
+        </Button>
+      </ListHeaderItem>
+    </ListHeader>
+    <ListRows class="mx-3 sm:mx-5" id="list-rows">
+      <ListRow v-for="row in rows" :key="row.name" v-slot="{ idx, column, item }" :row="row">
+        <ListRowItem :item="item">
+          <template #prefix>
+            <div v-if="column.key === 'phone'">
+              <PhoneIcon class="h-4 w-4" />
+            </div>
+          </template>
+          <template #default="{ label }">
+            <div
+              v-if="['modified', 'creation'].includes(column.key)"
+              class="truncate text-base"
+              @click="
+                (event) =>
+                  emit('applyFilter', {
+                    event,
+                    idx,
+                    column,
+                    item,
+                    firstColumn: columns[0],
+                  })
+              "
+            >
+              <Tooltip :text="item.label">
+                <div>{{ item.timeAgo }}</div>
+              </Tooltip>
+            </div>
+            <div v-else-if="column.type === 'Check'">
+              <FormControl type="checkbox" :modelValue="item" :disabled="true" class="text-ink-gray-9" />
+            </div>
+            <div v-else-if="column.key === '_liked_by'">
+              <Button
+                v-if="column.key == '_liked_by'"
+                variant="ghosted"
+                :class="isLiked(item) ? 'fill-red-500' : 'fill-white'"
+                @click.stop.prevent="() => emit('likeDoc', { name: row.name, liked: isLiked(item) })"
+              >
+                <HeartIcon class="h-4 w-4" />
+              </Button>
+            </div>
+            <div
+              v-else
+              class="truncate text-base"
+              @click="
+                (event) =>
+                  emit('applyFilter', {
+                    event,
+                    idx,
+                    column,
+                    item,
+                    firstColumn: columns[0],
+                  })
+              "
+            >
+              {{ label }}
+            </div>
+          </template>
+        </ListRowItem>
+      </ListRow>
+    </ListRows>
+    <ListSelectBanner>
+      <template #actions="{ selections, unselectAll }">
+        <Dropdown :options="listBulkActionsRef.bulkActions(selections, unselectAll)">
+          <Button icon="more-horizontal" variant="ghost" />
+        </Dropdown>
+      </template>
+    </ListSelectBanner>
+  </ListView>
+  <ListFooter
+    v-if="pageLengthCount"
+    class="border-t px-3 py-2 sm:px-5"
+    v-model="pageLengthCount"
+    :options="{
+      rowCount: options.rowCount,
+      totalCount: options.totalCount,
+    }"
+    @loadMore="emit('loadMore')"
+  />
+  <ListBulkActions
+    ref="listBulkActionsRef"
+    v-model="list"
+    doctype="Address"
+    :options="{
+      hideAssign: true,
+    }"
+  />
+</template>
+<script setup>
+import HeartIcon from '@/components/Icons/HeartIcon.vue'
+import PhoneIcon from '@/components/Icons/PhoneIcon.vue'
+import ListBulkActions from '@/components/ListBulkActions.vue'
+import {
+  ListView,
+  ListHeader,
+  ListHeaderItem,
+  ListRows,
+  ListRow,
+  ListSelectBanner,
+  ListRowItem,
+  ListFooter,
+  Tooltip,
+  Dropdown,
+} from 'frappe-ui'
+import { sessionStore } from '@/stores/session'
+import { ref, computed, watch } from 'vue'
+import { useRoute } from 'vue-router'
+
+const props = defineProps({
+  rows: {
+    type: Array,
+    required: true,
+  },
+  columns: {
+    type: Array,
+    required: true,
+  },
+  options: {
+    type: Object,
+    default: () => ({
+      selectable: true,
+      showTooltip: true,
+      resizeColumn: false,
+      totalCount: 0,
+      rowCount: 0,
+    }),
+  },
+})
+
+const emit = defineEmits([
+  'loadMore',
+  'updatePageCount',
+  'columnWidthUpdated',
+  'applyFilter',
+  'applyLikeFilter',
+  'likeDoc',
+])
+
+const route = useRoute()
+
+const pageLengthCount = defineModel()
+const list = defineModel('list')
+
+const isLikeFilterApplied = computed(() => {
+  return list.value.params?.filters?._liked_by ? true : false
+})
+
+const { user } = sessionStore()
+
+function isLiked(item) {
+  if (item) {
+    let likedByMe = JSON.parse(item)
+    return likedByMe.includes(user)
+  }
+}
+
+watch(pageLengthCount, (val, old_value) => {
+  if (val === old_value) return
+  emit('updatePageCount', val)
+})
+
+const listBulkActionsRef = ref(null)
+
+defineExpose({
+  customListActions: computed(() => listBulkActionsRef.value?.customListActions),
+})
+</script>

--- a/frontend/src/pages/MobileCustomer.vue
+++ b/frontend/src/pages/MobileCustomer.vue
@@ -144,6 +144,13 @@
           :columns="columns"
           :options="{ selectable: false, showTooltip: false }"
         />
+        <AddressesListView
+          class="mt-4"
+          v-if="tab.label === 'Addresses' && rows.length"
+          :rows="rows"
+          :columns="columns"
+          :options="{ selectable: false, showTooltip: false }"
+        />
         <div
           v-if="!rows.length && tab.name !== 'Details'"
           class="grid flex-1 place-items-center text-xl font-medium text-ink-gray-4"
@@ -165,12 +172,14 @@ import SectionFields from '@/components/SectionFields.vue'
 import Icon from '@/components/Icon.vue'
 import LayoutHeader from '@/components/LayoutHeader.vue'
 import AddressModal from '@/components/Modals/AddressModal.vue'
+import AddressesListView from '@/components/ListViews/AddressesListView.vue'
 import OpportunitiesListView from '@/components/ListViews/OpportunitiesListView.vue'
 import ContactsListView from '@/components/ListViews/ContactsListView.vue'
 import DetailsIcon from '@/components/Icons/DetailsIcon.vue'
 import CameraIcon from '@/components/Icons/CameraIcon.vue'
 import OpportunitiesIcon from '@/components/Icons/OpportunitiesIcon.vue'
 import ContactsIcon from '@/components/Icons/ContactsIcon.vue'
+import AddressIcon from '@/components/Icons/AddressIcon.vue'
 import { globalStore } from '@/stores/global'
 import { usersStore } from '@/stores/users'
 import { statusesStore } from '@/stores/statuses'
@@ -395,6 +404,12 @@ const tabs = [
     icon: h(ContactsIcon, { class: 'h-4 w-4' }),
     count: computed(() => contacts.data?.length),
   },
+  {
+    label: 'Addresses',
+    label: __('Addresses'),
+    icon: h(AddressIcon, { class: 'h-4 w-4' }),
+    count: computed(() => addresses.data?.length),
+  },
 ]
 
 const opportunities = createListResource({
@@ -448,21 +463,65 @@ async function getContactsList() {
   return list
 }
 
+async function getAddressesList() { 
+  const address_names = await call('next_crm.api.address.get_linked_address', {
+    link_doctype: 'Customer', 
+    link_name: props.customerId,
+  })
+
+  const list = createListResource({
+    type: 'list',
+    doctype: 'Address',
+    fields: [
+      'name',
+      'address_title',
+      'address_type',
+      'address_line1',
+      'phone',
+      'modified',
+    ],
+    filters: {
+      name: ['in', address_names],
+    },
+    orderBy: 'modified desc',
+    pageLength: 20,
+    auto: true,
+  })
+
+  return list
+}
+
 const contacts = await getContactsList();
+const addresses = await getAddressesList();
 
 const rows = computed(() => {
   let list = []
-  list = !tabIndex.value ? opportunities : contacts
+  if (tabIndex.value === 1)
+    list = opportunities
+  else if (tabIndex.value === 2)
+    list = contacts
+  else if (tabIndex.value === 3)
+    list = addresses
 
   if (!list.data) return []
 
   return list.data.map((row) => {
-    return !tabIndex.value ? getOpportunityRowObject(row) : getContactRowObject(row)
+    if (tabIndex.value === 1)
+      return getOpportunityRowObject(row)
+    else if (tabIndex.value === 2)
+      return getContactRowObject(row)
+    else if (tabIndex.value === 3)
+      return getAddressRowObject(row)
   })
 })
 
 const columns = computed(() => {
-  return tabIndex.value === 0 ? opportunityColumns : contactColumns
+  if (tabIndex.value === 1)
+    return opportunityColumns
+  else if (tabIndex.value === 2)
+    return contactColumns
+  else if (tabIndex.value === 3)
+    return addressColumns
 })
 
 function getOpportunityRowObject(opportunity) {
@@ -514,6 +573,19 @@ function getContactRowObject(contact) {
   }
 }
 
+function getAddressRowObject(address) {
+  return {
+    address_title: address.address_title,
+    address_type: address.address_type,
+    address_line1: address.address_line1,
+    phone: address.phone,
+    modified: {
+      label: dateFormat(address.modified, dateTooltipFormat),
+      timeAgo: __(timeAgo(address.modified)),
+    },
+  }
+}
+
 const opportunityColumns = [
   {
     label: __('Amount'),
@@ -561,6 +633,34 @@ const contactColumns = [
   {
     label: __('Company'),
     key: 'company_name',
+    width: '12rem',
+  },
+  {
+    label: __('Last modified'),
+    key: 'modified',
+    width: '8rem',
+  },
+]
+
+const addressColumns = [
+  {
+    label: __('Title'),
+    key: 'address_title',
+    width: '17rem',
+  },
+  {
+    label: __('Type'),
+    key: 'address_type',
+    width: '12rem' ,
+  },
+  {
+    label: __('Line 1'),
+    key: 'address_line1',
+    width: '12rem',
+  },
+  {
+    label: __('Phone'),
+    key: 'phone',
     width: '12rem',
   },
   {

--- a/next_crm/api/address.py
+++ b/next_crm/api/address.py
@@ -1,0 +1,53 @@
+import frappe
+from frappe import _
+
+
+@frappe.whitelist()
+def get_address(name):
+    Address = frappe.qb.DocType("Address")
+
+    query = frappe.qb.from_(Address).select("*").where(Address.name == name).limit(1)
+
+    address = query.run(as_dict=True)
+    if not len(address):
+        frappe.throw(_("Address not found"), frappe.DoesNotExistError)
+    address = address.pop()
+
+    address["doctype"] = "Address"
+    return address
+
+
+@frappe.whitelist()
+def get_linked_address(link_doctype, link_name=None):
+    dict_list = frappe.get_list(
+        "Dynamic Link",
+        [
+            ["parenttype", "=", "Address"],
+            ["link_doctype", "=", link_doctype],
+            ["link_name", "=", link_name],
+        ],
+    )
+
+    names = []
+    for dict in dict_list:
+        doc = frappe.get_doc("Dynamic Link", dict.name)
+        names.append(doc.parent)
+
+    return names
+
+
+@frappe.whitelist()
+def get_linked_docs(address, link_doctype=None):
+    dict_list = frappe.get_list(
+        "Dynamic Link",
+        [
+            ["parenttype", "=", "Address"],
+            ["link_doctype", "=", link_doctype],
+            ["parent", "=", address],
+        ],
+    )
+
+    names = []
+    for dict in dict_list:
+        doc = frappe.get_doc("Dynamic Link", dict.name)
+        names.append(doc.link_name)

--- a/next_crm/hooks.py
+++ b/next_crm/hooks.py
@@ -143,6 +143,7 @@ override_doctype_class = {
     "Opportunity": "next_crm.overrides.opportunity.Opportunity",
     "ToDo": "next_crm.overrides.todo.ToDo",
     "Prospect": "next_crm.overrides.prospect.Prospect",
+    "Address": "next_crm.overrides.address.CustomAddress",
 }
 
 # Document Events

--- a/next_crm/overrides/address.py
+++ b/next_crm/overrides/address.py
@@ -1,0 +1,53 @@
+from frappe.contacts.doctype.address.address import Address
+
+
+class CustomAddress(Address):
+    @staticmethod
+    def default_list_data():
+        columns = [
+            {
+                "label": "Name",
+                "type": "Data",
+                "key": "name",
+                "width": "10rem",
+            },
+            {
+                "label": "Title",
+                "type": "Data",
+                "key": "address_title",
+                "width": "10rem",
+            },
+            {
+                "label": "Line 1",
+                "type": "Data",
+                "key": "address_line1",
+                "width": "12rem",
+            },
+            {
+                "label": "Address Type",
+                "type": "Data",
+                "key": "address_type",
+                "width": "8rem",
+            },
+            {
+                "label": "Phone",
+                "type": "Data",
+                "key": "phone",
+                "width": "12rem",
+            },
+            {
+                "label": "Last Modified",
+                "type": "Datetime",
+                "key": "modified",
+                "width": "8rem",
+            },
+        ]
+        rows = [
+            "name",
+            "address_title",
+            "address_line1",
+            "address_type",
+            "phone",
+            "modified",
+        ]
+        return {"columns": columns, "rows": rows}


### PR DESCRIPTION
### Description
Add `Address` list view to `customers` and `prospects`
This is a part of 3 part change -
1.  Part 1 to show linked addresses
2. Part 2 will introduce a new page for `Addresses` like we have for `Contacts`.
3. Part 3 will introduce a modal to link addresses from front end.

<img width="1426" alt="Screenshot 2025-03-10 at 7 45 51 PM" src="https://github.com/user-attachments/assets/0c476488-7f9c-4d4c-804a-66f926f949bd" />
