### PR TITLE
Add Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# 🐛 Bug Report
+
+## **Description**
+[Provide a clear and concise description of the bug.]
+
+## **Steps to Reproduce**
+1. Go to [specific page].
+2. Click on [specific action].
+3. Observe [unexpected behavior].
+
+## **Expected Behavior**
+[Describe what you expected to happen.]
+
+## **Actual Behavior**
+[Describe what actually happened.]
+
+## **Screenshots/Screencasts**
+[Attach screenshots or screencasts, if applicable.]
+
+## **Environment**
+- OS: [e.g., Windows 10, macOS 13]
+- Browser: [e.g., Chrome 109, Firefox 90]
+
+## **Additional Context**
+[Add any other context about the problem here.]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest a new idea or feature for Next CRM
+labels: Feature-Request
+---
+
+# 🚀 Feature Request
+
+## **Description**
+[Provide a clear and concise description of the feature you would like to request.]
+
+## **Motivation**
+[Explain why this feature is important and what problem it solves.]
+
+## **Mockups or References**
+[Include screenshots, diagrams, or links to similar features, if applicable.]
+
+## **Acceptance Criteria:**
+[Define acceptance criteria with specific conditions and requirements that must be met to complete this request.]
+- [ ] [Condition 1]
+- [ ] [Condition 2]
+- [ ] [Condition 3]
+
+## **Additional Context**
+[Add any other context, links, or references that would help explain this feature request.]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+## Description
+
+<!-- What do we want to achieve with this PR? -->
+
+## Relevant Technical Choices
+
+<!-- For Code Reviewers: Please describe your changes. -->
+
+## Testing Instructions
+
+<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->
+
+## Additional Information:
+
+<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->
+
+## Screenshot/Screencast
+
+<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
+
+
+## Checklist
+
+<!-- Check these after creating PR, use NA if something is not applicable -->
+
+- [ ] I have carefully reviewed the code before submitting it for review.
+- [ ] This code is adequately covered by unit tests to validate its functionality.
+- [ ] I have conducted thorough testing to ensure it functions as intended.
+- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
+
+<!--
+Example:
+
+Fixes #123
+Partially addresses #22
+See #834
+-->
+
+Fixes #


### PR DESCRIPTION
Next CRM lacks proper templating for Issue and PR.
Adding templates will add standard practices.