### PR TITLE
Add user mention and persistent menu bar to notes

### DIFF
--- a/frontend/src/components/Modals/NoteModal.vue
+++ b/frontend/src/components/Modals/NoteModal.vue
@@ -44,8 +44,8 @@
           <TextEditor
             variant="outline"
             ref="content"
-            editor-class="!prose-sm overflow-auto min-h-[180px] max-h-80 py-1.5 px-2 rounded border border-[--surface-gray-2] bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors"
-            :bubbleMenu="true"
+            editor-class="!prose-sm overflow-auto min-h-[180px] max-h-80 py-1.5 px-2 rounded-b border border-[--surface-gray-2] bg-surface-gray-2 placeholder-ink-gray-4 hover:border-outline-gray-modals hover:bg-surface-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3 text-ink-gray-8 transition-colors"
+            :fixed-menu="true"
             :content="_note.note"
             @change="(val) => (_note.note = val)"
             :placeholder="__('Took a call with John Doe and discussed the new project.')"

--- a/frontend/src/components/Modals/NoteModal.vue
+++ b/frontend/src/components/Modals/NoteModal.vue
@@ -49,6 +49,7 @@
             :content="_note.note"
             @change="(val) => (_note.note = val)"
             :placeholder="__('Took a call with John Doe and discussed the new project.')"
+            :mentions="users"
           />
         </div>
       </div>
@@ -60,7 +61,7 @@
 import ArrowUpRightIcon from '@/components/Icons/ArrowUpRightIcon.vue'
 import { capture } from '@/telemetry'
 import { TextEditor, call } from 'frappe-ui'
-import { ref, nextTick, watch } from 'vue'
+import { ref, computed, nextTick, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { usersStore } from '@/stores/users'
 
@@ -84,7 +85,7 @@ const notes = defineModel('reloadNotes')
 
 const emit = defineEmits(['after'])
 
-const { getUser } = usersStore()
+const { users: usersList, getUser } = usersStore()
 import { dateFormat } from '@/utils'
 
 const router = useRouter()
@@ -139,6 +140,17 @@ function redirect() {
   }
   router.push({ name: name, params: params })
 }
+
+const users = computed(() => {
+  return (
+    usersList.data
+      ?.filter((user) => user.enabled)
+      .map((user) => ({
+        label: user.full_name.trimEnd(),
+        value: user.name,
+      })) || []
+  )
+})
 
 watch(
   () => show.value,


### PR DESCRIPTION
## Description

Notes in Next CRM doesn't allow mentioning users, even through it is allowed in ERPNext.
Also, the bubble menu is not intuitive enough and is better to be replaced with the fixed menu.

## Relevant Technical Choices

- Disabled bubble menu in favour of fixed menu at top
- Added ability to mention users
- Mentioning someone doesn't trigger a notification yet

## Testing Instructions

Create a note in Next CRM and try to style the contents with the fixed menu bar and mention users

## Screenshot/Screencast

<img width="594" alt="Screenshot 2025-03-13 at 2 11 20 AM" src="https://github.com/user-attachments/assets/ed8a7e04-8b8a-4a25-9b8a-013b0a11a999" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #