### PR TITLE
Update notes layout to be wider and longer

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -27,10 +27,7 @@
           :messages="whatsappMessages.data"
         />
       </div>
-      <div
-        v-else-if="title == 'Notes'"
-        class="grid grid-cols-1 gap-4 px-3 pb-3 sm:px-10 sm:pb-5 lg:grid-cols-2 xl:grid-cols-3"
-      >
+      <div v-else-if="title == 'Notes'" class="grid grid-cols-1 gap-4 px-3 pb-3 sm:px-10 sm:pb-5">
         <div v-for="note in activities" @click="modalRef.showNote(note)">
           <NoteArea :note="note" v-model="all_activities" />
         </div>

--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="activity group flex h-48 cursor-pointer flex-col justify-between gap-2 rounded-md bg-surface-gray-1 px-4 py-3 hover:bg-surface-gray-2"
+    class="activity group flex max-h-64 cursor-pointer flex-col justify-between gap-2 rounded-md bg-surface-gray-1 px-4 py-3 hover:bg-surface-gray-2"
   >
     <div class="flex items-center justify-between">
       <div class="truncate text-lg font-medium text-ink-gray-8">

--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -1,44 +1,48 @@
 <template>
-  <div
-    class="activity group flex max-h-64 cursor-pointer flex-col justify-between gap-2 rounded-md bg-surface-gray-1 px-4 py-3 hover:bg-surface-gray-2"
-  >
-    <div class="flex items-center justify-between">
-      <div class="truncate text-lg font-medium text-ink-gray-8">
-        {{ note.custom_title }}
-      </div>
-      <Dropdown
-        :options="[
-          {
-            label: __('Delete'),
-            icon: 'trash-2',
-            onClick: () => deleteNote(note.name),
-          },
-        ]"
-        @click.stop
-        class="h-6 w-6"
-      >
-        <Button icon="more-horizontal" variant="ghosted" class="!h-6 !w-6 hover:bg-surface-gray-2" />
-      </Dropdown>
-    </div>
-    <TextEditor
-      v-if="note.note"
-      :content="note.note"
-      :editable="false"
-      editor-class="!prose-sm max-w-none !text-sm text-ink-gray-5 focus:outline-none"
-      class="flex-1 overflow-hidden"
-    />
-    <div class="mt-1 flex items-center justify-between gap-2">
-      <div class="flex items-center gap-2 truncate">
-        <UserAvatar :user="note.owner" size="xs" />
-        <div class="truncate text-sm text-ink-gray-8" :title="getUser(note.owner).full_name">
+  <div class="activity group">
+    <div class="mb-1 flex items-center justify-stretch gap-2 py-1 text-base">
+      <div class="inline-flex items-center flex-wrap gap-1 text-ink-gray-5">
+        <UserAvatar class="mr-1" :user="note.owner" size="md" />
+        <span class="font-medium text-ink-gray-8" :title="getUser(note.owner).full_name">
           {{ getUser(note.owner).full_name }}
+        </span>
+      </div>
+      <div class="flex items-center gap-2 ml-auto whitespace-nowrap">
+        <Tooltip :text="dateFormat(note.modified, dateTooltipFormat)">
+          <div class="truncate text-sm text-ink-gray-7">
+            {{ __(timeAgo(note.modified)) }}
+          </div>
+        </Tooltip>
+        <Dropdown
+          :options="[
+            {
+              label: __('Delete'),
+              icon: 'trash-2',
+              onClick: () => deleteNote(note.name),
+            },
+          ]"
+          @click.stop
+          class="h-6 w-6"
+        >
+          <Button icon="more-horizontal" variant="ghosted" class="!h-6 !w-6 hover:bg-surface-gray-2" />
+        </Dropdown>
+      </div>
+    </div>
+    <div
+      class="activity group flex max-h-64 cursor-pointer flex-col justify-between gap-2 rounded-md bg-surface-gray-1 px-4 py-3 hover:bg-surface-gray-2"
+    >
+      <div class="flex items-center justify-between">
+        <div class="truncate text-lg font-medium text-ink-gray-8">
+          {{ note.custom_title }}
         </div>
       </div>
-      <Tooltip :text="dateFormat(note.modified, dateTooltipFormat)">
-        <div class="truncate text-sm text-ink-gray-7">
-          {{ __(timeAgo(note.modified)) }}
-        </div>
-      </Tooltip>
+      <TextEditor
+        v-if="note.note"
+        :content="note.note"
+        :editable="false"
+        editor-class="!prose-sm max-w-none !text-sm text-ink-gray-5 focus:outline-none"
+        class="flex-1 overflow-hidden"
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Description

Notes layout is currently a grid of small post notes.
Upon further inspection, it was discovered that when notes are quite big, the current layout is not very practical.
This design update makes it similar to other activities pages, taking up the full width

## Relevant Technical Choices

- Height is set to a max of 64 pixels to have enough details visible
- Grid is set to 1 column for max width usage

## Testing Instructions

Open the notes page and check if it has one note per row.

## Screenshot/Screencast

Before -
<img width="1429" alt="Screenshot 2025-03-13 at 2 17 08 AM" src="https://github.com/user-attachments/assets/34ebce15-3527-4bda-b612-e04c4ce8bd19" />

After -
<img width="1430" alt="Screenshot 2025-03-13 at 2 35 37 PM" src="https://github.com/user-attachments/assets/d654babf-76a3-4822-b4c0-80f192c43e3c" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)