### PR TITLE
Create prospect on opportunity creation

### DIFF
--- a/frontend/src/components/Modals/OpportunityModal.vue
+++ b/frontend/src/components/Modals/OpportunityModal.vue
@@ -83,7 +83,7 @@ const opportunity = reactive({
 })
 
 const isOpportunityCreating = ref(false)
-const chooseExistingCustomer = ref(false)
+const chooseExistingCustomer = ref(true)
 const chooseExistingContact = ref(false)
 
 const sections = createResource({


### PR DESCRIPTION
## Description

Currently on opportunity creation we create a `Customer`.
Upon going through the flow, it was discovered that it is better to create a `Prospect` whenever possible instead.

## Relevant Technical Choices

- Check if a `Customer` with same name exists, if it does link with that, if not check `Prospect`
- If `Prospect` already exists, it links `Opportunity` with that, else it creates a new `Prospect`

## Testing Instructions

- Create a new opportunity using `customer_name`, it should create a prospect instead of customer
- Convert a lead to opportunity. It should also create Prospect
- In Opportunity quick entry modal, choose existing should be toggled on by default.

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)