### PR TITLE
Fix filters in Kanban view

### DIFF
--- a/next_crm/api/doc.py
+++ b/next_crm/api/doc.py
@@ -379,7 +379,7 @@ def get_data(
             order = kc.get("order")
             if (
                 column_field in filters
-                and filters.get(column_field) != kc.name
+                and filters.get(column_field) != kc.get("name")
                 or kc.get("delete")
             ):
                 column_data = []


### PR DESCRIPTION
## Description

Filters in Kanban view were broken due to accessing name as a instance variable in a dictionary.

## Testing Instructions

- Go to Kanban view
- Apply filters
- Check if filters apply appropriately and without any errors in console

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)