### PR TITLE
Make link in convert to opportunity more visible

### DIFF
--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -234,7 +234,7 @@
         <Link
           v-if="existingCustomerChecked"
           class="form-control mt-2.5"
-          variant="outline"
+          variant="subtle"
           size="md"
           :value="existingCustomer"
           doctype="Customer"
@@ -261,7 +261,7 @@
         <Link
           v-if="existingContactChecked"
           class="form-control mt-2.5"
-          variant="outline"
+          variant="subtle"
           size="md"
           :value="existingContact"
           doctype="Contact"

--- a/frontend/src/pages/MobileLead.vue
+++ b/frontend/src/pages/MobileLead.vue
@@ -119,7 +119,7 @@
         <Link
           v-if="existingCustomerChecked"
           class="form-control mt-2.5"
-          variant="outline"
+          variant="subtle"
           size="md"
           :value="existingCustomer"
           doctype="Customer"
@@ -146,7 +146,7 @@
         <Link
           v-if="existingContactChecked"
           class="form-control mt-2.5"
-          variant="outline"
+          variant="subtle"
           size="md"
           :value="existingContact"
           doctype="Contact"


### PR DESCRIPTION
## Description

The link fields in `convert to opportunity` dialog are hard to see.
They can be made more visible by using the subtle variant of link.

## Testing Instructions

Open convert to opportunity dialog on any lead and turn the toggle for selecting existing contact or customer to on

## Screenshot/Screencast

Before - 
<img width="612" alt="Screenshot 2025-03-14 at 3 04 01 PM" src="https://github.com/user-attachments/assets/cd1908ff-f7cb-49a4-af38-f1139ffe49d7" />

After -
<img width="613" alt="Screenshot 2025-03-14 at 3 04 38 PM" src="https://github.com/user-attachments/assets/f66cf467-5bd5-4a65-bf58-89c2ab302849" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)