### PR TITLE
Reduce execution time for get_contacts api

### DIFF
--- a/next_crm/api/session.py
+++ b/next_crm/api/session.py
@@ -33,42 +33,33 @@ def get_users():
 
 @frappe.whitelist()
 def get_contacts():
-    contacts = frappe.get_all(
-        "Contact",
-        fields=[
-            "name",
-            "salutation",
-            "first_name",
-            "last_name",
-            "full_name",
-            "gender",
-            "address",
-            "designation",
-            "image",
-            "email_id",
-            "mobile_no",
-            "phone",
-            "company_name",
-            "modified",
-        ],
-        order_by="first_name asc",
-        distinct=True,
-    )
+    from itertools import chain
 
-    for contact in contacts:
-        contact["email_ids"] = frappe.get_all(
-            "Contact Email",
-            filters={"parenttype": "Contact", "parent": contact.name},
-            fields=["name", "email_id", "is_primary"],
+    def get_contact_data(filters: dict = None):
+        contacts = get_contact_list(filters)
+        contact_names = [c.name for c in contacts]
+        contact_emails = get_contact_emails(contact_names)
+        contact_phone = get_contact_phones(contact_names)
+        for contact in contacts:
+            contact.email_ids = [e for e in contact_emails if e.parent == contact.name]
+            contact.phone_nos = [p for p in contact_phone if p.parent == contact.name]
+
+        contact_name_set = {c.name for c in contacts}
+        filtered_contact_names = list(
+            {
+                c.parent
+                for c in chain(contact_emails, contact_phone)
+                if c.parent not in contact_name_set
+            }
         )
+        return contacts, filtered_contact_names
 
-        contact["phone_nos"] = frappe.get_all(
-            "Contact Phone",
-            filters={"parenttype": "Contact", "parent": contact.name},
-            fields=["name", "phone", "is_primary_phone", "is_primary_mobile_no"],
-        )
+    filters = {"mobile_no": ["is", "set"]}
+    contacts_1, filtered_contact_names = get_contact_data(filters)
 
-    return contacts
+    filters.update({"name": ["in", filtered_contact_names]})
+    contacts_2, _ = get_contact_data(filters)
+    return list(chain(contacts_1, contacts_2))
 
 
 @frappe.whitelist()
@@ -94,3 +85,44 @@ def get_customers():
     ).run(as_dict=1)
 
     return customers
+
+
+def get_contact_list(filters: dict = None):
+    return frappe.get_all(
+        "Contact",
+        fields=[
+            "name",
+            "salutation",
+            "first_name",
+            "last_name",
+            "full_name",
+            "gender",
+            "address",
+            "designation",
+            "image",
+            "email_id",
+            "mobile_no",
+            "phone",
+            "company_name",
+            "modified",
+        ],
+        order_by="first_name asc",
+        filters=filters,
+        distinct=True,
+    )
+
+
+def get_contact_emails(parent_contact_names: list):
+    return frappe.get_all(
+        "Contact Email",
+        filters={"parenttype": "Contact", "parent": ["in", parent_contact_names]},
+        fields=["name", "email_id", "is_primary", "parent"],
+    )
+
+
+def get_contact_phones(parent_contact_names: list):
+    return frappe.get_all(
+        "Contact Phone",
+        filters={"parenttype": "Contact", "parent": ["in", parent_contact_names]},
+        fields=["name", "phone", "is_primary_phone", "is_primary_mobile_no", "parent"],
+    )

--- a/next_crm/api/session.py
+++ b/next_crm/api/session.py
@@ -54,11 +54,15 @@ def get_contacts():
         )
         return contacts, filtered_contact_names
 
+    # Get contacts  from `tabContact` which has mobile number set.
     filters = {"mobile_no": ["is", "set"]}
     contacts_1, filtered_contact_names = get_contact_data(filters)
 
+    # Get list of contacts to be fetched from  `tabContact Email` and `tabContact Phone` combine them, and finally fetch the contacts.
     filters.update({"name": ["in", filtered_contact_names]})
     contacts_2, _ = get_contact_data(filters)
+
+    # Combine the contacts from both the queries.
     return list(chain(contacts_1, contacts_2))
 
 


### PR DESCRIPTION
Initially `get_contacts` API takes more than ~2 sec on avg when there are over ~1k  contacts within the system, which in turn increase load time and more white screen on `/next-crm`.

This pr improves the performance of the API by eliminating extra records from the list and improving how data is extracted from db.

ref: https://github.com/rtCamp/erp-rtcamp/issues/2108#issuecomment-2712788920