### PR TITLE
Fix permissions error in dynamic link queries

### DIFF
--- a/next_crm/api/address.py
+++ b/next_crm/api/address.py
@@ -18,40 +18,26 @@ def get_address(name):
 
 
 @frappe.whitelist()
-def get_linked_address(link_doctype, link_name=None):
-    dynamic_links = frappe.get_all(
-        "Dynamic Link",
+def get_linked_address(link_doctype, link_name):
+    addresses = frappe.get_list(
+        "Address",
         [
-            ["parenttype", "=", "Address"],
-            ["link_doctype", "=", link_doctype],
-            ["link_name", "=", link_name],
+            ["Dynamic Link", "link_doctype", "=", link_doctype],
+            ["Dynamic Link", "link_name", "=", link_name],
         ],
         pluck="name",
     )
 
-    names = []
-    for name in dynamic_links:
-        doc = frappe.get_doc("Dynamic Link", name)
-        names.append(doc.parent)
-
-    return names
+    return addresses
 
 
 @frappe.whitelist()
-def get_linked_docs(address, link_doctype=None):
-    dynamic_links = frappe.get_all(
-        "Dynamic Link",
-        [
-            ["parenttype", "=", "Address"],
-            ["link_doctype", "=", link_doctype],
-            ["parent", "=", address],
-        ],
-        pluck="name",
-    )
+def get_linked_docs(address, link_doctype):
+    address_doc = frappe.get_doc("Address", address)
 
     names = []
-    for name in dynamic_links:
-        doc = frappe.get_doc("Dynamic Link", name)
-        names.append(doc.link_name)
+    for link in address_doc.links:
+        if link.link_doctype == link_doctype:
+            names.append(link.link_name)
 
     return names

--- a/next_crm/api/address.py
+++ b/next_crm/api/address.py
@@ -19,7 +19,7 @@ def get_address(name):
 
 @frappe.whitelist()
 def get_linked_address(link_doctype, link_name=None):
-    dynamic_links = frappe.get_list(
+    dynamic_links = frappe.get_all(
         "Dynamic Link",
         [
             ["parenttype", "=", "Address"],
@@ -39,7 +39,7 @@ def get_linked_address(link_doctype, link_name=None):
 
 @frappe.whitelist()
 def get_linked_docs(address, link_doctype=None):
-    dynamic_links = frappe.get_list(
+    dynamic_links = frappe.get_all(
         "Dynamic Link",
         [
             ["parenttype", "=", "Address"],

--- a/next_crm/api/contact.py
+++ b/next_crm/api/contact.py
@@ -188,7 +188,7 @@ def search_emails(txt: str):
 
 @frappe.whitelist()
 def get_linked_contact(link_doctype, link_name=None):
-    dict_list = frappe.get_list(
+    dict_list = frappe.get_all(
         "Dynamic Link",
         [
             ["parenttype", "=", "Contact"],

--- a/next_crm/api/contact.py
+++ b/next_crm/api/contact.py
@@ -187,20 +187,14 @@ def search_emails(txt: str):
 
 
 @frappe.whitelist()
-def get_linked_contact(link_doctype, link_name=None):
-    dict_list = frappe.get_all(
-        "Dynamic Link",
+def get_linked_contact(link_doctype, link_name):
+    contacts = frappe.get_list(
+        "Contact",
         [
-            ["parenttype", "=", "Contact"],
-            ["link_doctype", "=", link_doctype],
-            ["link_name", "=", link_name],
+            ["Dynamic Link", "link_doctype", "=", link_doctype],
+            ["Dynamic Link", "link_name", "=", link_name],
         ],
+        pluck="name",
     )
 
-    names = []
-
-    for dict in dict_list:
-        doc = frappe.get_doc("Dynamic Link", dict.name)
-        names.append(doc.parent)
-
-    return names
+    return contacts


### PR DESCRIPTION
## Description

Dynamic links are used to get linked contacts, addresses and customers.
This doctype is not accessible by sales user.

As we just need the list of doc names, get_all can be used instead of get_list.

## Testing Instructions

Open Prospect, Customers and Addresses pages through a user with "Sales Manager" and "Sales User" roles.

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)