### PR TITLE
hide create button for users without permission

### DIFF
--- a/frontend/src/pages/Addresses.vue
+++ b/frontend/src/pages/Addresses.vue
@@ -9,6 +9,7 @@
         :actions="addressesListView.customListActions"
       />
       <Button
+        v-if="hasCreateAccess"
         variant="solid"
         :label="__('Create')"
         @click="showAddressModal = true"
@@ -87,6 +88,7 @@ import { customersStore } from '@/stores/customers.js'
 import { dateFormat, dateTooltipFormat, timeAgo } from '@/utils'
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
+import { call } from 'frappe-ui'
 
 const { getCustomer } = customersStore()
 const router = useRouter()
@@ -95,6 +97,15 @@ const showAddressModal = ref(false)
 const showQuickEntryModal = ref(false)
 
 const addressesListView = ref(null)
+
+// Create button is shown only with write access
+const hasCreateAccess = ref(false)
+
+call('next_crm.api.doc.check_create_access', {
+  doctype: "Address"
+}).then((show) => {
+  hasCreateAccess.value = show;       
+})
 
 // addresses data is loaded in the ViewControls component
 const addresses = ref({})

--- a/frontend/src/pages/Customers.vue
+++ b/frontend/src/pages/Customers.vue
@@ -9,6 +9,7 @@
         :actions="customersListView.customListActions"
       />
       <Button
+        v-if="hasCreateAccess"
         variant="solid"
         :label="__('Create')"
         @click="showCustomerModal = true"
@@ -86,10 +87,20 @@ import {
   formatNumberIntoCurrency,
 } from '@/utils'
 import { ref, computed } from 'vue'
+import { call } from 'frappe-ui'
 
 const customersListView = ref(null)
 const showCustomerModal = ref(false)
 const showQuickEntryModal = ref(false)
+
+// Create button is shown only with write access
+const hasCreateAccess = ref(false)
+
+call('next_crm.api.doc.check_create_access', {
+  doctype: "Customer"
+}).then((show) => {
+  hasCreateAccess.value = show;       
+})
 
 // customers data is loaded in the ViewControls component
 const customers = ref({})

--- a/frontend/src/pages/EmailTemplates.vue
+++ b/frontend/src/pages/EmailTemplates.vue
@@ -9,6 +9,7 @@
         :actions="emailTemplatesListView.customListActions"
       />
       <Button
+        v-if="hasCreateAccess"
         variant="solid"
         :label="__('Create')"
         @click="() => showEmailTemplate()"
@@ -77,8 +78,18 @@ import EmailTemplatesListView from '@/components/ListViews/EmailTemplatesListVie
 import EmailTemplateModal from '@/components/Modals/EmailTemplateModal.vue'
 import { dateFormat, dateTooltipFormat, timeAgo } from '@/utils'
 import { computed, ref } from 'vue'
+import { call } from 'frappe-ui'
 
 const emailTemplatesListView = ref(null)
+
+// Create button is shown only with write access
+const hasCreateAccess = ref(false)
+
+call('next_crm.api.doc.check_create_access', {
+  doctype: "Email Template"
+}).then((show) => {
+  hasCreateAccess.value = show;       
+})
 
 // emailTemplates data is loaded in the ViewControls component
 const emailTemplates = ref({})

--- a/frontend/src/pages/Leads.vue
+++ b/frontend/src/pages/Leads.vue
@@ -9,6 +9,7 @@
         :actions="leadsListView.customListActions"
       />
       <Button
+        v-if="hasCreateAccess"
         variant="solid"
         :label="__('Create')"
         @click="showLeadModal = true"
@@ -314,7 +315,7 @@ import {
   website,
   formatTime,
 } from '@/utils'
-import { Avatar, Tooltip, Dropdown } from 'frappe-ui'
+import { Avatar, Tooltip, Dropdown, call } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { ref, computed, reactive, h } from 'vue'
 
@@ -329,6 +330,15 @@ const showLeadModal = ref(false)
 const showQuickEntryModal = ref(false)
 
 const defaults = reactive({})
+
+// Create button is shown only with write access
+const hasCreateAccess = ref(false)
+
+call('next_crm.api.doc.check_create_access', {
+  doctype: "Lead"
+}).then((show) => {
+  hasCreateAccess.value = show;       
+})
 
 // leads data is loaded in the ViewControls component
 const leads = ref({})

--- a/frontend/src/pages/Opportunities.vue
+++ b/frontend/src/pages/Opportunities.vue
@@ -9,6 +9,7 @@
         :actions="opportunitiesListView.customListActions"
       />
       <Button
+        v-if="hasCreateAccess"
         variant="solid"
         :label="__('Create')"
         @click="showOpportunityModal = true"
@@ -294,7 +295,7 @@ import {
   formatNumberIntoCurrency,
   formatTime,
 } from '@/utils'
-import { Tooltip, Avatar, Dropdown } from 'frappe-ui'
+import { Tooltip, Avatar, Dropdown, call } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { ref, reactive, computed, h } from 'vue'
 
@@ -310,6 +311,15 @@ const showOpportunityModal = ref(false)
 const showQuickEntryModal = ref(false)
 
 const defaults = reactive({})
+
+// Create button is shown only with write access
+const hasCreateAccess = ref(false)
+
+call('next_crm.api.doc.check_create_access', {
+  doctype: "Opportunity"
+}).then((show) => {
+  hasCreateAccess.value = show;       
+})
 
 // opportunities data is loaded in the ViewControls component
 const opportunities = ref({})

--- a/frontend/src/pages/Prospects.vue
+++ b/frontend/src/pages/Prospects.vue
@@ -5,7 +5,7 @@
     </template>
     <template #right-header>
       <CustomActions v-if="prospectsListView?.customListActions" :actions="prospectsListView.customListActions" />
-      <Button variant="solid" :label="__('Create')" @click="showProspectModal = true">
+      <Button v-if="hasCreateAccess" variant="solid" :label="__('Create')" @click="showProspectModal = true">
         <template #prefix><FeatherIcon name="plus" class="h-4" /></template>
       </Button>
     </template>
@@ -85,7 +85,7 @@ import { customersStore } from '@/stores/customers'
 import { statusesStore } from '@/stores/statuses'
 import { callEnabled } from '@/composables/settings'
 import { dateFormat, dateTooltipFormat, timeAgo, website, formatNumberIntoCurrency, formatTime } from '@/utils'
-import { Tooltip, Avatar, Dropdown } from 'frappe-ui'
+import { call } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { ref, reactive, computed, h } from 'vue'
 
@@ -101,6 +101,15 @@ const showProspectModal = ref(false)
 const showQuickEntryModal = ref(false)
 
 const defaults = reactive({})
+
+// Create button is shown only with write access
+const hasCreateAccess = ref(false)
+
+call('next_crm.api.doc.check_create_access', {
+  doctype: 'Prospect',
+}).then((show) => {
+  hasCreateAccess.value = show
+})
 
 // prospects data is loaded in the ViewControls component
 const prospects = ref({})

--- a/next_crm/api/doc.py
+++ b/next_crm/api/doc.py
@@ -809,3 +809,10 @@ def getCounts(d, doctype):
         filters={"parenttype": doctype, "parent": d.get("name")},
     )
     return d
+
+
+@frappe.whitelist()
+def check_create_access(doctype):
+    if frappe.has_permission(doctype, "create"):
+        return True
+    return False


### PR DESCRIPTION
## Description

Even when a user has only read access, the create button is still shown.
This can be hidden for users without create access.

## Relevant Technical Choices

Make a reactive variable whose value is set by an API which checks if user has create access.

## Testing Instructions

1. Create two users, one with Create access and one with only Read access
2. Check the Create access user should be able to see the create button
3. User with only read access should not be able to see the create button

## Screenshot/Screencast

User with only read access
<img width="1210" alt="Screenshot 2025-03-18 at 4 42 51 PM" src="https://github.com/user-attachments/assets/48bdeafa-2baa-4fd8-a745-e6bea9e52d56" />

User with create access
<img width="1207" alt="Screenshot 2025-03-18 at 4 44 27 PM" src="https://github.com/user-attachments/assets/960c4d20-dc17-4dea-9463-62b518e6825d" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)