### PR TITLE
rename convert to opportunity in prospect

### DIFF
--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -9,9 +9,9 @@
     </template>
     <template #right-header>
       <Button
-        :label="__('Convert to Opportunity')"
+        :label="__('Create Opportunity')"
         variant="solid"
-        @click=convertToOpportunity
+        @click=createOpportunity
       />
     </template>
   </LayoutHeader>
@@ -601,16 +601,16 @@ function getAddressRowObject(address) {
   // Convert to Opportunity
   const showConvertToOpportunityModal = ref(false)
 
-  async function convertToOpportunity() {
+  async function createOpportunity() {
 
       let opportunity = await call(
-        'next_crm.overrides.prospect.convert_to_opportunity',
+        'next_crm.overrides.prospect.create_opportunity',
         {
           prospect: prospect.name,
         },
       )
       if (opportunity) {
-        capture('convert_prospect_to_opportunity')
+        capture('create_prospect_from_opportunity')
         router.push({ name: 'Opportunity', params: { opportunityId: opportunity } })
       }
   }

--- a/next_crm/overrides/prospect.py
+++ b/next_crm/overrides/prospect.py
@@ -71,12 +71,13 @@ class Prospect(Prospect):
 
 
 @frappe.whitelist()
-def convert_to_opportunity(prospect, doc=None):
-    if not (doc and doc.flags.get("ignore_permissions")) and not frappe.has_permission(
-        "Prospect", "write", prospect
-    ):
+def create_opportunity(prospect, doc=None):
+    if (
+        not (doc and doc.flags.get("ignore_permissions"))
+        and not frappe.has_permission("Prospect", "write", prospect)
+    ) or not frappe.has_permission("Opportunity", "create"):
         frappe.throw(
-            _("Not allowed to convert Prospect to Opportunity"), frappe.PermissionError
+            _("Not allowed to create Opportunity from Prospect"), frappe.PermissionError
         )
 
     prospect = frappe.get_cached_doc("Prospect", prospect)


### PR DESCRIPTION
## Description
Currently to create an `Opportunity` from `Prospect`, we use the button `Convert to Opportunity` which is incorrect, as we don't convert but create with same details instead.

Hence, the button and associated function should more appropriately be renamed to `Create Opportunity`

## Relevant Technical Choices

Renamed button and functions

## Testing Instructions

- Go to a prospect
- The button should be called create opportunity
- Clicking on it should create a new opportunity and redirect there

## Screenshot/Screencast

<img width="1200" alt="Screenshot 2025-03-18 at 5 01 18 PM" src="https://github.com/user-attachments/assets/a34695e3-f5c2-470e-b8ad-043b0b6cb6d0" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)