### PR TITLE
add buton to create customer from prospect

### DIFF
--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -8,11 +8,27 @@
       </Breadcrumbs>
     </template>
     <template #right-header>
-      <Button
-        :label="__('Create Opportunity')"
-        variant="solid"
-        @click=createOpportunity
-      />
+      <Dropdown
+        v-slot="{ open }"
+        :button= "'Create'"
+        :options="[
+          {
+            label: __('Opportunity'),
+            onClick: createOpportunity
+          },
+          {
+            label: __('Customer'),
+            onClick: createCustomer
+          },
+        ]"
+        @click.stop
+      >
+        <Button :label="'Create'">
+          <template #suffix>
+            <FeatherIcon :name="open ? 'chevron-up' : 'chevron-down'" class="h-4" />
+          </template>
+        </Button>
+      </Dropdown>
     </template>
   </LayoutHeader>
   <div ref="parentRef" class="flex h-full">
@@ -191,6 +207,7 @@
   import {
     Tooltip,
     Breadcrumbs,
+    Dropdown,
     Tabs,
     call,
     createListResource,
@@ -555,6 +572,36 @@ function getAddressRowObject(address) {
       timeAgo: __(timeAgo(address.modified)),
     },
   }
+}
+
+async function createCustomer() {
+  $dialog({
+    title: __('Create Customer'),
+    message: __('Are you sure you want to create a new Customer from this Prospect\'s details?'),
+    actions: [
+      {
+        label: __('Create'),
+        theme: 'green',
+        variant: 'solid',
+        async onClick(close) {
+          try {
+            const customer = await call('next_crm.overrides.prospect.create_customer', {
+              prospect: prospect.name,
+            })
+            close()
+            router.push({ name: 'Customer', params: { customerId: customer } })
+          } catch (error) {
+            createToast({
+              title: __('Error'),
+              text: error,
+              icon: 'x',
+              iconClasses: 'text-ink-red-4',
+            });
+          }
+        },
+      },
+    ],
+  })
 }
 
   // Convert to Opportunity

--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -10,7 +10,7 @@
     <template #right-header>
       <Dropdown
         v-slot="{ open }"
-        :button= "'Create'"
+        :button= "__('Create')"
         :options="[
           {
             label: __('Opportunity'),

--- a/next_crm/overrides/prospect.py
+++ b/next_crm/overrides/prospect.py
@@ -1,7 +1,11 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 import frappe
-from erpnext.crm.doctype.prospect.prospect import Prospect
+from erpnext.crm.doctype.prospect.prospect import (
+    Prospect,
+    make_customer,
+    make_opportunity,
+)
 from frappe import _
 
 
@@ -61,14 +65,6 @@ class Prospect(Prospect):
             "kanban_fields": '["annual_revenue", "_assign", "modified"]',
         }
 
-    def create_opportunity(self):
-        from erpnext.crm.doctype.prospect.prospect import make_opportunity
-
-        opportunity = make_opportunity(self.name)
-
-        opportunity.insert(ignore_permissions=True)
-        return opportunity.name
-
 
 @frappe.whitelist()
 def create_opportunity(prospect, doc=None):
@@ -81,5 +77,19 @@ def create_opportunity(prospect, doc=None):
         )
 
     prospect = frappe.get_cached_doc("Prospect", prospect)
-    opportunity = prospect.create_opportunity()
-    return opportunity
+    opportunity = make_opportunity(prospect.name)
+    opportunity.insert()
+    return opportunity.name
+
+
+@frappe.whitelist()
+def create_customer(prospect):
+    if not frappe.has_permission("Customer", "create"):
+        frappe.throw(
+            _("Not allowed to create Customer from Prospect"), frappe.PermissionError
+        )
+
+    prospect = frappe.get_cached_doc("Prospect", prospect)
+    customer = make_customer(prospect.name)
+    customer.insert()
+    return customer.name


### PR DESCRIPTION
## Description

Currently there is no way to create a customer from prospect in the Next CRM frontend, even when allowed from the backend.
The button can be added in a dropdown to make it similar as it is in ERP Next

## Relevant Technical Choices

Functions for creation were in overrided class, when they could be implemented in parent function so removed un-necessary code pieces.
The creation function internally calls the same API used in ERPNext backend.

## Testing Instructions

1. Open a Prospect.
2. Try creating a Customer and Opportunity from the Prospect.

## Screenshot/Screencast

Dropdown collapsed
<img width="1196" alt="Screenshot 2025-03-18 at 6 34 04 PM" src="https://github.com/user-attachments/assets/c88eafe0-c587-44af-bad3-a13eb93eef61" />

Dropdown opened
<img width="213" alt="Screenshot 2025-03-18 at 6 34 15 PM" src="https://github.com/user-attachments/assets/d932355c-4a42-4814-b018-2497779e7298" />

Confirmation dialog
<img width="400" alt="Screenshot 2025-03-18 at 6 34 30 PM" src="https://github.com/user-attachments/assets/1fe5ef59-a22e-46b8-8642-a7f50c1955a9" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)