### PR TITLE
add rename ability to lead and opportunity

### DIFF
--- a/frontend/src/components/Modals/RenameModal.vue
+++ b/frontend/src/components/Modals/RenameModal.vue
@@ -1,0 +1,110 @@
+<template>
+  <Dialog
+    v-model="show"
+    :options="{
+      title: __('Rename'),
+      size: 'md',
+      actions: [
+        {
+          label: __('Rename'),
+          variant: 'solid',
+          onClick: renameDoc,
+        },
+      ],
+    }"
+  >
+    <template #body-content>
+      <div>
+        <FormControl
+          :type="'text'"
+          size="md"
+          variant="subtle"
+          :disabled="false"
+          label="New Title"
+          v-model="_name.title"
+        />
+      </div>
+      <div class="mt-6">
+        <FormControl
+          :type="'text'"
+          size="md"
+          variant="subtle"
+          :disabled="false"
+          label="New Name"
+          v-model="_name.name"
+        />
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup>
+import { ref, nextTick, watch } from 'vue'
+import { createToast } from '@/utils'
+import { call } from 'frappe-ui'
+
+const props = defineProps({
+  title: {
+    type: String,
+    default: '',
+  },
+  doctype: {
+    type: String,
+    default: 'Opportunity',
+  },
+  docname: {
+    type: String,
+    default: '',
+  },
+  options: {
+    type: Object,
+    default: {
+      afterRename: () => {},
+    },
+  },
+})
+
+const _name = ref({
+  title: '',
+  name: '',
+})
+
+const show = defineModel()
+
+async function renameDoc() {
+  if (props.title === _name.value.title && props.docname === _name.value.name) return
+  try {
+    const renamed_docname = await call('frappe.model.rename_doc.update_document_title', {
+      doctype: props.doctype,
+      docname: props.docname,
+      title: _name.value.title,
+      name: _name.value.name,
+    })
+    show.value = false
+    createToast({
+      title: __(`${props.doctype} Renamed`),
+      icon: 'check',
+      iconClasses: 'text-ink-green-4',
+    })
+    props.options.afterRename && props.options.afterRename(renamed_docname)
+  } catch (error) {
+    createToast({
+      title: __('Error'),
+      text: error,
+      icon: 'x',
+      iconClasses: 'text-ink-red-4',
+    })
+  }
+}
+
+watch(
+  () => show.value,
+  (value) => {
+    if (!value) return
+    nextTick(() => {
+      _name.value.title = props.title
+      _name.value.name = props.docname
+    })
+  },
+)
+</script>

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -109,8 +109,8 @@
             </div>
             <div class="flex flex-col gap-2.5 truncate">
               <Tooltip :text="lead.data.lead_name || __('Set first name')">
-                <div class="truncate text-2xl font-medium text-ink-gray-9">
-                  {{ lead.data.lead_name || __('Untitled') }}
+                <div class="truncate text-2xl font-medium text-ink-gray-9" @click="showRenameModal = true">
+                  {{ lead.data.lead_name || lead.data.title || __('Untitled') }}
                 </div>
               </Tooltip>
               <div class="flex gap-1.5">
@@ -290,6 +290,15 @@
       }
     "
   />
+  <RenameModal
+      v-model="showRenameModal"
+      doctype="Lead"
+      :docname="lead?.data?.name"
+      :title="lead?.data?.title"
+      :options="{
+        afterRename: afterRename
+      }"
+  />
 </template>
 <script setup>
 import Icon from '@/components/Icon.vue'
@@ -315,6 +324,7 @@ import Activities from '@/components/Activities/Activities.vue'
 import AssignTo from '@/components/AssignTo.vue'
 import FilesUploader from '@/components/FilesUploader/FilesUploader.vue'
 import SidePanelModal from '@/components/Settings/SidePanelModal.vue'
+import RenameModal from '@/components/Modals/RenameModal.vue'
 import Link from '@/components/Controls/Link.vue'
 import Section from '@/components/Section.vue'
 import SectionFields from '@/components/SectionFields.vue'
@@ -402,6 +412,7 @@ onMounted(() => {
 const reload = ref(false)
 const showSidePanelModal = ref(false)
 const showFilesUploader = ref(false)
+const showRenameModal = ref(false)
 
 function updateLead(fieldname, value, callback) {
   value = Array.isArray(fieldname) ? '' : value
@@ -471,7 +482,7 @@ const breadcrumbs = computed(() => {
   }
 
   items.push({
-    label: lead.data.lead_name || __('Untitled'),
+    label: lead.data.lead_name || lead.data.title || __('Untitled'),
     route: { name: 'Lead', params: { leadId: lead.data.name } },
   })
   return items
@@ -659,5 +670,11 @@ const activities = ref(null)
 
 function openEmailBox() {
   activities.value.emailBox.show = true
+}
+
+function afterRename(renamed_docname) {
+  router.push({ name: props.doctype, params: { leadId: renamed_docname } }).then(() => {
+    location.reload();
+  });
 }
 </script>

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -67,8 +67,8 @@
         </Tooltip>
         <div class="flex flex-col gap-2.5 truncat text-ink-gray-9">
           <Tooltip :text="customer.data?.name || opportunity.data?.party_name || __('Set an customer')">
-            <div class="truncate text-2xl font-medium">
-              {{ customer.data?.name || opportunity.data?.party_name || __('Untitled') }}
+            <div class="truncate text-2xl font-medium" @click="showRenameModal = true">
+              {{ customer.data?.name || opportunity.data?.title || opportunity.data?.party_name || __('Untitled') }}
             </div>
           </Tooltip>
           <div class="flex gap-1.5">
@@ -310,6 +310,15 @@
       }
     "
   />
+  <RenameModal
+      v-model="showRenameModal"
+      doctype="Opportunity"
+      :docname="opportunity?.data?.name"
+      :title="opportunity?.data?.title"
+      :options="{
+        afterRename: afterRename
+      }"
+  />
 </template>
 <script setup>
 import Icon from '@/components/Icon.vue'
@@ -337,6 +346,7 @@ import AssignTo from '@/components/AssignTo.vue'
 import FilesUploader from '@/components/FilesUploader/FilesUploader.vue'
 import ContactModal from '@/components/Modals/ContactModal.vue'
 import SidePanelModal from '@/components/Settings/SidePanelModal.vue'
+import RenameModal from '@/components/Modals/RenameModal.vue'
 import Link from '@/components/Controls/Link.vue'
 import Section from '@/components/Section.vue'
 import SectionFields from '@/components/SectionFields.vue'
@@ -448,6 +458,7 @@ const reload = ref(false)
 const showCustomerModal = ref(false)
 const showSidePanelModal = ref(false)
 const showFilesUploader = ref(false)
+const showRenameModal = ref(false)
 const _customer = ref({})
 
 function updateOpportunity(fieldname, value, callback) {
@@ -518,7 +529,7 @@ const breadcrumbs = computed(() => {
   }
 
   items.push({
-    label: customer.data?.name || opportunity.data?.party_name || __('Untitled'),
+    label: customer.data?.name || opportunity.data?.title || opportunity.data?.party_name || __('Untitled'),
     route: { name: 'Opportunity', params: { opportunityId: opportunity.data.name } },
   })
   return items
@@ -730,6 +741,12 @@ const activities = ref(null)
 
 function openEmailBox() {
   activities.value.emailBox.show = true
+}
+
+function afterRename(renamed_docname) {
+  router.push({ name: props.doctype, params: { opportunityId: renamed_docname } }).then(() => {
+    location.reload();
+  });
 }
 </script>
 


### PR DESCRIPTION
## Description

Currently a Lead or Opportunity can be renamed from the the ERPNext backend but not from the Next CRM frontend.
This functionality can be added to the name labels.

## Relevant Technical Choices

1. Created a new modal which can rename and change title of a doc
2. Used the name in doc as the trigger for the dialog box
3. Added title fields with high priority as fallback breadcrumb and name choice.

## Testing Instructions

1. Open a opportunity or lead
2. Click on the title part of it
3. Type a new name or title
4. Check that it successfully renames on action button click

## Screenshot/Screencast


https://github.com/user-attachments/assets/514a49ce-7712-471a-b41b-b1021f2069c3




## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #84 