### PR TITLE
Add Sync With Google Calendar fields in Events FE

### DIFF
--- a/frontend/src/components/Activities/AllModals.vue
+++ b/frontend/src/components/Activities/AllModals.vue
@@ -31,6 +31,9 @@ import NoteModal from '@/components/Modals/NoteModal.vue'
 import { call } from 'frappe-ui'
 import { ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { usersStore } from '@/stores/users'
+
+const { getUser } = usersStore()
 
 const props = defineProps({
   doctype: String,
@@ -65,6 +68,8 @@ function showEvent(t) {
     starts_on: '',
     ends_on: '',
     status: 'Open',
+    sync_with_google_calendar: 1,
+    google_calendar: getUser().google_calendar,
   }
   showEventModal.value = true
 }

--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -100,6 +100,31 @@
             input-class="border-none"
           />
         </div>
+        <div class="flex flex-wrap items-center gap-2">
+          <FormControl
+            class="form-control"
+            type="checkbox"
+            v-model="_event.sync_with_google_calendar"
+            @change="(e) => (_event.sync_with_google_calendar = e.target.checked)"
+          />
+          <label
+            class="text-sm text-ink-gray-5"
+            @click="_event.sync_with_google_calendar = !_event.sync_with_google_calendar"
+          >
+            {{ __('Sync with Google Calendar') }}
+          </label>
+          <Link
+            v-if="_event.sync_with_google_calendar"
+            class="form-control"
+            :value="_event.google_calendar"
+            doctype="Google Calendar"
+            @change="(option) => (_event.google_calendar = option)"
+            :placeholder="__('Google Calendar')"
+            :hideMe="true"
+            :filters="{'enable': 1}"
+          >
+          </Link>
+        </div>
       </div>
     </template>
   </Dialog>
@@ -150,6 +175,8 @@ const _event = ref({
   status: 'Open',
   event_type: 'Private',
   event_category: 'Event',
+  sync_with_google_calendar: true,
+  google_calendar: getUser().google_calendar,
 })
 
 const eventMeta = ref(
@@ -177,6 +204,9 @@ const fields = createResource({
 async function updateEvent() {
   if (!_event.value.allocated_to) {
     _event.value.allocated_to = getUser().name
+  }
+  if (!_event.value.sync_with_google_calendar) {
+    _event.value.google_calendar = null
   }
   _event.value.assigned_by = getUser().name
   if (_event.value.name) {

--- a/frontend/src/stores/users.js
+++ b/frontend/src/stores/users.js
@@ -44,6 +44,7 @@ export const usersStore = defineStore('crm-users', () => {
         last_name: '',
         user_image: null,
         role: null,
+        google_calendar: null,
       }
     }
     return usersByName[email]

--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -503,6 +503,8 @@ def get_linked_events(name):
             "starts_on",
             "ends_on",
             "event_category",
+            "sync_with_google_calendar",
+            "google_calendar",
             "status",
             "event_type",
             "modified",

--- a/next_crm/api/session.py
+++ b/next_crm/api/session.py
@@ -28,6 +28,8 @@ def get_users():
             "Sales Manager" in frappe.get_roles(user.name)
             or user.name == "Administrator"
         )
+
+        user.google_calendar = frappe.db.get_value("Google Calendar", {"user": user.name, "enable": 1}, "name")
     return users
 
 


### PR DESCRIPTION
## Description

- Currently, in Create Event view, there is no option to select Google Calendar and Enable Sync with Google Calendar.
- Due to this, there was no way that an Event can be synced with Google Calendar.
- This PR introduces these fields in Create Event view.
- Also, it prefills the current authenticated user's Google Calendar if it's available.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

- [ ] Ensure you see the fields `Sync with Google Calendar` and `Google Calendar` in Create Event view.
- [ ] Creating an event with Google Calendar enabled, should sync that event with Google Calendar.
- [ ] Deleting this event should also delete event from the Google Calendar

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<img width="584" alt="image" src="https://github.com/user-attachments/assets/f6d0d266-98ad-4a86-bc52-65abd9ba1661" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #83 