### PR TITLE
Fix in filter when using the column field as filter

### DIFF
--- a/next_crm/api/doc.py
+++ b/next_crm/api/doc.py
@@ -374,17 +374,39 @@ def get_data(
             if field not in rows:
                 rows.append(field)
 
-        for kc in kanban_columns:
+        enabled_columns = []
+        cf_in_filter = True
+        if (
+            column_field in filters
+            and isinstance(filters.get(column_field), list)
+            and filters.get(column_field)[0] == "in"
+        ):
+            selected_columns = [
+                enabled_column.strip()
+                for enabled_column in filters.get(column_field)[1].split(",")
+            ]
+            for kc in kanban_columns:
+                if kc.get("name") not in selected_columns:
+                    continue
+                enabled_columns.append(kc)
+        else:
+            cf_in_filter = False
+            enabled_columns = kanban_columns
+
+        for kc in enabled_columns:
             column_filters = {column_field: kc.get("name")}
             order = kc.get("order")
+
             if (
                 column_field in filters
                 and filters.get(column_field) != kc.get("name")
+                and not cf_in_filter
                 or kc.get("delete")
             ):
                 column_data = []
             else:
-                column_filters.update(filters.copy())
+                if not cf_in_filter:
+                    column_filters.update(filters.copy())
                 page_length = 20
 
                 if kc.get("page_length"):


### PR DESCRIPTION
## Description

Currently Kanban "in" filter is skipped if applied on the column field.
The better fix is to hide the columns not in the "in" filter

## Relevant Technical Choices

The code will now iterate of the columns in filter and only show those if the "in" filter is used.

## Testing Instructions

1. Go to Kanban view
2. Select the column field as the filter
3. Use the "in" operator
4. Add some columns to filter on
5. Check if only the intended columns are visible

## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #74 