### PR TITLE
Add patch to add contact sidepanel section to lead

### DIFF
--- a/next_crm/patches.txt
+++ b/next_crm/patches.txt
@@ -11,3 +11,4 @@ next_crm.patches.v1_0.update_opportunity_quick_entry_layout
 next_crm.patches.v1_0.update_crm_settings_lead_contact_creation
 next_crm.patches.v1_0.add_address_sidepanel_layout
 next_crm.patches.v1_0.add_multiple_address_sidepanel_section
+next_crm.patches.v1_0.add_lead_contact_sidepanel_layout

--- a/next_crm/patches/v1_0/add_lead_contact_sidepanel_layout.py
+++ b/next_crm/patches/v1_0/add_lead_contact_sidepanel_layout.py
@@ -1,0 +1,26 @@
+import json
+
+import frappe
+
+
+def execute():
+    if not frappe.db.exists("CRM Fields Layout", "Lead-Side Panel"):
+        return
+
+    contact_section = {
+        "label": "Contacts",
+        "name": "contacts_section",
+        "opened": True,
+        "editable": False,
+        "contacts": [],
+    }
+
+    docpanel = frappe.get_doc("CRM Fields Layout", "Lead-Side Panel")
+    parsed_layout = json.loads(docpanel.layout)
+    if not any(item.get("name") == "contacts_section" for item in parsed_layout):
+        if parsed_layout[0].get("name") == "addresses_section":
+            parsed_layout.insert(1, contact_section)
+        else:
+            parsed_layout.insert(0, contact_section)
+    docpanel.layout = json.dumps(parsed_layout)
+    docpanel.save()


### PR DESCRIPTION
## Description

Although leads can now support multiple contacts, the section is not added automatically to CRM Fields layout via patch. This PR will add the section automatically for users

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)