### PR TITLE
Remove primary contact functionality from lead

### DIFF
--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -293,13 +293,6 @@
                             <div class="truncate">
                               {{ contact.full_name }}
                             </div>
-                            <Badge
-                              v-if="contact.is_primary"
-                              class="ml-2"
-                              variant="outline"
-                              :label="__('Primary')"
-                              theme="green"
-                            />
                           </div>
                           <div class="flex items-center">
                             <Dropdown :options="contactOptions(contact)">
@@ -778,15 +771,6 @@ function contactOptions(contact) {
       onClick: () => removeContact(contact.name),
     },
   ]
-
-  if (!contact.is_primary) {
-    options.push({
-      label: __('Set as Primary Contact'),
-      icon: h(SuccessIcon, { class: 'h-4 w-4' }),
-      onClick: () => setPrimaryContact(contact.name),
-    })
-  }
-
   return options
 }
 

--- a/next_crm/api/contact.py
+++ b/next_crm/api/contact.py
@@ -233,7 +233,6 @@ def get_lead_opportunity_contacts(doctype, docname):
     linked_contacts = []
     for contact in contacts:
         contact = frappe.get_doc("Contact", contact).as_dict()
-        is_primary = contact.is_primary
 
         _contact = {
             "name": contact.name,
@@ -241,7 +240,6 @@ def get_lead_opportunity_contacts(doctype, docname):
             "full_name": contact.full_name,
             "email": get_primary_email(contact),
             "mobile_no": get_primary_mobile_no(contact),
-            "is_primary": is_primary,
         }
         linked_contacts.append(_contact)
     return linked_contacts


### PR DESCRIPTION
## Description

The primary contact functionality can't work in the same way it worked on Opportunity due to the shift to dynamic link instead of the child table.
This feature will be added again after being reworked to support this way of linking contacts.

## Relevant Technical Choices

Removed the primary contact button on a temporary basis from lead.

## Testing Instructions

- [ ] Open lead and select contact
- [ ] There shouldn't be a option in the three dot menu to set a contact as primary contact

## Screenshot/Screencast

Before
<img width="226" alt="Screenshot 2025-03-24 at 4 24 01 PM" src="https://github.com/user-attachments/assets/9f2aba17-5c8e-441d-a3f7-eabd0740a23d" />

After

<img width="226" alt="Screenshot 2025-03-24 at 4 24 55 PM" src="https://github.com/user-attachments/assets/269969e7-2732-484b-b504-d369d0e8c089" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)