### PR TITLE
Fix overflow in link fields

### DIFF
--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="space-y-1.5">
+  <div class="space-y-1.5 p-[2px] -m-[2px]">
     <label class="block" :class="labelClasses" v-if="attrs.label">
       {{ __(attrs.label) }}
     </label>

--- a/frontend/src/components/Fields.vue
+++ b/frontend/src/components/Fields.vue
@@ -12,36 +12,20 @@
       >
         {{ section.label }}
       </div>
-      <div
-        class="grid gap-4"
-        :class="
-          section.columns
-            ? 'grid-cols-' + section.columns
-            : 'grid-cols-2 sm:grid-cols-3'
-        "
-      >
+      <div class="grid gap-4" :class="section.columns ? 'grid-cols-' + section.columns : 'grid-cols-2 sm:grid-cols-3'">
         <div v-for="field in section.fields" :key="field.name">
           <div
             class="settings-field"
             v-if="
-              (field.type == 'Check' ||
-                (field.read_only && data[field.name]) ||
-                !field.read_only ||
-                !field.hidden) &&
+              (field.type == 'Check' || (field.read_only && data[field.name]) || !field.read_only || !field.hidden) &&
               (!field.depends_on || field.display_via_depends_on)
             "
           >
-            <div
-              v-if="field.type != 'Check'"
-              class="mb-2 text-sm text-ink-gray-5"
-            >
+            <div v-if="field.type != 'Check'" class="mb-2 text-sm text-ink-gray-5">
               {{ __(field.label) }}
               <span
                 class="text-red-500"
-                v-if="
-                  field.mandatory ||
-                  (field.mandatory_depends_on && field.mandatory_via_depends_on)
-                "
+                v-if="field.mandatory || (field.mandatory_depends_on && field.mandatory_via_depends_on)"
                 >*</span
               >
             </div>
@@ -65,10 +49,7 @@
                 <IndicatorIcon :class="field.prefix" />
               </template>
             </FormControl>
-            <div
-              v-else-if="field.type == 'Check'"
-              class="flex items-center gap-2"
-            >
+            <div v-else-if="field.type == 'Check'" class="flex items-center gap-2">
               <FormControl
                 class="form-control"
                 type="checkbox"
@@ -76,17 +57,14 @@
                 @change="(e) => (data[field.name] = e.target.checked)"
                 :disabled="Boolean(field.read_only)"
               />
-              <label
-                class="text-sm text-ink-gray-5"
-                @click="data[field.name] = !data[field.name]"
-              >
+              <label class="text-sm text-ink-gray-5" @click="data[field.name] = !data[field.name]">
                 {{ __(field.label) }}
                 <span class="text-red-500" v-if="field.mandatory">*</span>
               </label>
             </div>
             <div class="flex gap-1" v-else-if="field.type === 'Link'">
               <Link
-                class="form-control flex-1"
+                class="form-control flex-1 truncate"
                 :value="data[field.name]"
                 :doctype="field.options"
                 :filters="field.filters"
@@ -143,9 +121,7 @@
               input-class="border-none"
             />
             <FormControl
-              v-else-if="
-                ['Small Text', 'Text', 'Long Text'].includes(field.type)
-              "
+              v-else-if="['Small Text', 'Text', 'Long Text'].includes(field.type)"
               type="textarea"
               :placeholder="getPlaceholder(field)"
               v-model="data[field.name]"

--- a/frontend/src/components/frappe-ui/Autocomplete.vue
+++ b/frontend/src/components/frappe-ui/Autocomplete.vue
@@ -18,32 +18,23 @@
               :class="inputClasses"
               @click="() => togglePopover()"
             >
-              <div class="flex items-center">
+              <div class="flex text-base leading-5 items-center truncate">
                 <slot name="prefix" />
-                <span
-                  class="overflow-hidden text-ellipsis whitespace-nowrap text-base leading-5"
-                  v-if="selectedValue"
-                >
+                <span v-if="selectedValue" class="truncate">
                   {{ displayValue(selectedValue) }}
                 </span>
-                <span class="text-base leading-5 text-ink-gray-4" v-else>
+                <span v-else class="text-ink-gray-4 truncate">
                   {{ placeholder || '' }}
                 </span>
               </div>
-              <FeatherIcon
-                name="chevron-down"
-                class="h-4 w-4 text-ink-gray-5"
-                aria-hidden="true"
-              />
+              <FeatherIcon name="chevron-down" class="h-4 w-4 text-ink-gray-5" aria-hidden="true" />
             </button>
           </div>
         </slot>
       </template>
       <template #body="{ isOpen }">
         <div v-show="isOpen">
-          <div
-            class="relative mt-1 rounded-lg bg-surface-modal text-base shadow-2xl"
-          >
+          <div class="relative mt-1 rounded-lg bg-surface-modal text-base shadow-2xl">
             <div class="relative px-1.5 pt-1.5">
               <ComboboxInput
                 ref="search"
@@ -65,16 +56,8 @@
                 <FeatherIcon name="x" class="w-4 text-ink-gray-8" />
               </button>
             </div>
-            <ComboboxOptions
-              class="my-1 max-h-[12rem] overflow-y-auto px-1.5"
-              static
-            >
-              <div
-                class="mt-1.5"
-                v-for="group in groups"
-                :key="group.key"
-                v-show="group.items.length > 0"
-              >
+            <ComboboxOptions class="my-1 max-h-[12rem] overflow-y-auto px-1.5" static>
+              <div class="mt-1.5" v-for="group in groups" :key="group.key" v-show="group.items.length > 0">
                 <div
                   v-if="group.group && !group.hideLabel"
                   class="truncate bg-surface-modal px-2.5 py-1.5 text-sm font-medium text-ink-gray-5"
@@ -94,14 +77,8 @@
                       { 'bg-surface-gray-3': active },
                     ]"
                   >
-                    <slot
-                      name="item-prefix"
-                      v-bind="{ active, selected, option }"
-                    />
-                    <slot
-                      name="item-label"
-                      v-bind="{ active, selected, option }"
-                    >
+                    <slot name="item-prefix" v-bind="{ active, selected, option }" />
+                    <slot name="item-label" v-bind="{ active, selected, option }">
                       <div class="flex-1 truncate text-ink-gray-7">
                         {{ option.label }}
                       </div>
@@ -109,21 +86,12 @@
                   </li>
                 </ComboboxOption>
               </div>
-              <li
-                v-if="groups.length == 0"
-                class="my-1.5 rounded-md px-2.5 py-1.5 text-base text-ink-gray-5"
-              >
+              <li v-if="groups.length == 0" class="my-1.5 rounded-md px-2.5 py-1.5 text-base text-ink-gray-5">
                 No results found
               </li>
             </ComboboxOptions>
-            <div
-              v-if="slots.footer"
-              class="border-t border-outline-gray-modals p-1.5"
-            >
-              <slot
-                name="footer"
-                v-bind="{ value: search?.el._value, close }"
-              ></slot>
+            <div v-if="slots.footer" class="border-t border-outline-gray-modals p-1.5">
+              <slot name="footer" v-bind="{ value: search?.el._value, close }"></slot>
             </div>
           </div>
         </div>
@@ -133,12 +101,7 @@
 </template>
 
 <script setup>
-import {
-  Combobox,
-  ComboboxInput,
-  ComboboxOptions,
-  ComboboxOption,
-} from '@headlessui/vue'
+import { Combobox, ComboboxInput, ComboboxOptions, ComboboxOption } from '@headlessui/vue'
 import { Popover, Button, FeatherIcon } from 'frappe-ui'
 import { ref, computed, useAttrs, useSlots, watch, nextTick } from 'vue'
 
@@ -203,9 +166,7 @@ function close() {
 const groups = computed(() => {
   if (!props.options || props.options.length == 0) return []
 
-  let groups = props.options[0]?.group
-    ? props.options
-    : [{ group: '', items: props.options }]
+  let groups = props.options[0]?.group ? props.options : [{ group: '', items: props.options }]
 
   return groups
     .map((group, i) => {
@@ -225,9 +186,7 @@ function filterOptions(options) {
   }
   return options.filter((option) => {
     let searchTexts = [option.label, option.value]
-    return searchTexts.some((text) =>
-      (text || '').toString().toLowerCase().includes(query.value.toLowerCase()),
-    )
+    return searchTexts.some((text) => (text || '').toString().toLowerCase().includes(query.value.toLowerCase()))
   })
 }
 
@@ -279,19 +238,11 @@ const inputClasses = computed(() => {
       'border border-outline-gray-2 bg-surface-white placeholder-ink-gray-4 hover:border-outline-gray-3 hover:shadow-sm focus:bg-surface-white focus:border-outline-gray-4 focus:shadow-sm focus:ring-0 focus-visible:ring-2 focus-visible:ring-outline-gray-3',
     disabled: [
       'border bg-surface-menu-bar placeholder-ink-gray-3',
-      props.variant === 'outline'
-        ? 'border-outline-gray-2'
-        : 'border-transparent',
+      props.variant === 'outline' ? 'border-outline-gray-2' : 'border-transparent',
     ],
   }[variant]
 
-  return [
-    sizeClasses,
-    paddingClasses,
-    variantClasses,
-    textColor.value,
-    'transition-colors w-full',
-  ]
+  return [sizeClasses, paddingClasses, variantClasses, textColor.value, 'transition-colors w-full']
 })
 
 defineExpose({ query })


### PR DESCRIPTION
## Description

The link fields when space constraint overflows their boundaries.

## Relevant Technical Choices

Added relevant css classes to hide the overflown text.

## Testing Instructions

- Check a link field with large text
- The field should not be overflowing

## Screenshot/Screencast

Before
<img width="162" alt="Screenshot 2025-03-25 at 1 54 10 AM" src="https://github.com/user-attachments/assets/dca3859e-f4f2-4cf2-a120-475a0bfda823" />

After
<img width="164" alt="Screenshot 2025-03-25 at 1 55 53 AM" src="https://github.com/user-attachments/assets/64acf1b1-1ae8-4faa-9c3a-41438d8e0ca6" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #96 