### PR TITLE
Don't truncate title field in Kanban view

### DIFF
--- a/frontend/src/pages/Leads.vue
+++ b/frontend/src/pages/Leads.vue
@@ -116,7 +116,7 @@
         </div>
         <div
           v-else-if="getRow(itemName, titleField).label"
-          class="truncate text-base"
+          class="text-base"
         >
           {{ getRow(itemName, titleField).label }}
         </div>

--- a/frontend/src/pages/Opportunities.vue
+++ b/frontend/src/pages/Opportunities.vue
@@ -100,7 +100,7 @@
         </div>
         <div
           v-else-if="getRow(itemName, titleField).label"
-          class="truncate text-base"
+          class="text-base"
         >
           {{ getRow(itemName, titleField).label }}
         </div>


### PR DESCRIPTION
## Description

The title field is truncated in Kanban to prevent overflow.
This although looks better is not very practical when used with the title fields of opportunity and lead.
The truncate class can be removed to remove size restriction from title.

## Relevant Technical Choices

Removed truncate class from title field

## Testing Instructions

- [ ] Create a lead or opportunity with very large title field
- [ ] Go to kanban view
- [ ] Ensure the title field is also the title field of kanban in kanban settings
- [ ] Check that the title field should be visible in entirety irrespective of size.

## Additional Information:

## Screenshot/Screencast

Before
<img width="286" alt="Screenshot 2025-03-25 at 2 29 03 AM" src="https://github.com/user-attachments/assets/7e775772-291c-49b5-9bb1-f91db6c91599" />

After
<img width="294" alt="Screenshot 2025-03-25 at 2 28 23 AM" src="https://github.com/user-attachments/assets/3d4d15ed-fbef-45b8-981f-19b80560c128" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Ref rtCamp/erp-rtcamp#2208 