### PR TITLE
Replace title with custom_title in ToDo

### DIFF
--- a/frontend/src/components/Activities/AllModals.vue
+++ b/frontend/src/components/Activities/AllModals.vue
@@ -50,7 +50,7 @@ const event = ref({})
 
 function showToDo(t) {
   todo.value = t || {
-    title: '',
+    custom_title: '',
     description: '',
     allocated_to: '',
     date: '',

--- a/frontend/src/components/Modals/ToDoModal.vue
+++ b/frontend/src/components/Modals/ToDoModal.vue
@@ -33,7 +33,7 @@
       <div class="flex flex-col gap-4">
         <div>
           <FormControl
-            ref="title"
+            ref="custom_title"
             :label="__('Title')"
             v-model="_todo.custom_title"
             :placeholder="__('Call with John Doe')"
@@ -138,10 +138,10 @@ const emit = defineEmits(['updateToDo', 'after'])
 const router = useRouter()
 const { getUser } = usersStore()
 
-const title = ref(null)
+const custom_title = ref(null)
 const editMode = ref(false)
 const _todo = ref({
-  title: '',
+  custom_title: '',
   description: '',
   allocated_to: '',
   assigned_by: '',
@@ -205,7 +205,7 @@ async function updateToDo() {
 function render() {
   editMode.value = false
   nextTick(() => {
-    title.value?.el?.focus?.()
+    custom_title.value?.el?.focus?.()
     _todo.value = { ...props.todo }
     if (_todo.value.description) {
       editMode.value = true


### PR DESCRIPTION
## Description

At some places there was `title` used instead of `custom_title` causing both being sent in the `frappe.client.insert` call.
This needs to be replaced with `custom_title`

## Relevant Technical Choices

Replaced instances of `title` with `custom_title`

## Testing Instructions

- [ ] Create ToDo
- [ ] Update ToDo
- [ ] Check the `frappe.client.insert` call's todo in network tab of inspector

## Checklist

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)