### PR TITLE
Support dynamic link in quick entry

### DIFF
--- a/frontend/src/components/Fields.vue
+++ b/frontend/src/components/Fields.vue
@@ -12,36 +12,20 @@
       >
         {{ section.label }}
       </div>
-      <div
-        class="grid gap-4"
-        :class="
-          section.columns
-            ? 'grid-cols-' + section.columns
-            : 'grid-cols-2 sm:grid-cols-3'
-        "
-      >
+      <div class="grid gap-4" :class="section.columns ? 'grid-cols-' + section.columns : 'grid-cols-2 sm:grid-cols-3'">
         <div v-for="field in section.fields" :key="field.name">
           <div
             class="settings-field"
             v-if="
-              (field.type == 'Check' ||
-                (field.read_only && data[field.name]) ||
-                !field.read_only ||
-                !field.hidden) &&
+              (field.type == 'Check' || (field.read_only && data[field.name]) || !field.read_only || !field.hidden) &&
               (!field.depends_on || field.display_via_depends_on)
             "
           >
-            <div
-              v-if="field.type != 'Check'"
-              class="mb-2 text-sm text-ink-gray-5"
-            >
+            <div v-if="field.type != 'Check'" class="mb-2 text-sm text-ink-gray-5">
               {{ __(field.label) }}
               <span
                 class="text-red-500"
-                v-if="
-                  field.mandatory ||
-                  (field.mandatory_depends_on && field.mandatory_via_depends_on)
-                "
+                v-if="field.mandatory || (field.mandatory_depends_on && field.mandatory_via_depends_on)"
                 >*</span
               >
             </div>
@@ -65,10 +49,7 @@
                 <IndicatorIcon :class="field.prefix" />
               </template>
             </FormControl>
-            <div
-              v-else-if="field.type == 'Check'"
-              class="flex items-center gap-2"
-            >
+            <div v-else-if="field.type == 'Check'" class="flex items-center gap-2">
               <FormControl
                 class="form-control"
                 type="checkbox"
@@ -76,10 +57,7 @@
                 @change="(e) => (data[field.name] = e.target.checked)"
                 :disabled="Boolean(field.read_only)"
               />
-              <label
-                class="text-sm text-ink-gray-5"
-                @click="data[field.name] = !data[field.name]"
-              >
+              <label class="text-sm text-ink-gray-5" @click="data[field.name] = !data[field.name]">
                 {{ __(field.label) }}
                 <span class="text-red-500" v-if="field.mandatory">*</span>
               </label>
@@ -89,6 +67,27 @@
                 class="form-control flex-1"
                 :value="data[field.name]"
                 :doctype="field.options"
+                :filters="field.filters"
+                @change="(v) => (data[field.name] = v)"
+                :placeholder="getPlaceholder(field)"
+                :onCreate="field.create"
+              />
+              <Button
+                v-if="data[field.name] && field.edit"
+                class="shrink-0"
+                :label="__('Edit')"
+                @click="field.edit(data[field.name])"
+              >
+                <template #prefix>
+                  <EditIcon class="h-4 w-4" />
+                </template>
+              </Button>
+            </div>
+            <div class="flex gap-1" v-else-if="field.type === 'Dynamic Link'">
+              <Link
+                class="form-control flex-1"
+                :value="data[field.name]"
+                :doctype="data[field.options]"
                 :filters="field.filters"
                 @change="(v) => (data[field.name] = v)"
                 :placeholder="getPlaceholder(field)"
@@ -143,9 +142,7 @@
               input-class="border-none"
             />
             <FormControl
-              v-else-if="
-                ['Small Text', 'Text', 'Long Text'].includes(field.type)
-              "
+              v-else-if="['Small Text', 'Text', 'Long Text'].includes(field.type)"
               type="textarea"
               :placeholder="getPlaceholder(field)"
               v-model="data[field.name]"


### PR DESCRIPTION
## Description

Currently quick entry doesn't support Dynamic Link.
This causes us to use workarounds instead of it being straight forward solution.

## Relevant Technical Choices

Reusing the existing `link` field but with the doctype value being dynamically changed based on the value of the field set in it's `options`.

## Testing Instructions

- [ ] Edit a quick entry menu
- [ ] Add a field which is dynamic field along with the field it is based on
- [ ] The dynamic field should get filtered just like it does in ERPNext

## Additional Information:

This PR is part of 3 part PR -

1. Adding dynamic link
2. Changing opportunity from selection in Opportunity QE
3. Changing the link field to show `title` wherever possible instead of `name`

## Screenshot/Screencast

https://github.com/user-attachments/assets/67135b96-8b8b-4d25-97f2-ae93357b9bca



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)