### PR TITLE
Create opportunity using opportunity from field

### DIFF
--- a/frontend/src/components/Modals/OpportunityModal.vue
+++ b/frontend/src/components/Modals/OpportunityModal.vue
@@ -113,7 +113,7 @@ const filteredSections = computed(() => {
   let _filteredSections = []
 
   if (chooseExistingCustomerLeadProspect.value) {
-    _filteredSections.push(allSections.find((s) => s.label === 'Select Customer'))
+    _filteredSections.push(allSections.find((s) => s.label === 'Select Opportunity From'))
   } else {
     _filteredSections.push(allSections.find((s) => s.label === 'Customer Details'))
   }
@@ -125,7 +125,7 @@ const filteredSections = computed(() => {
   }
 
   allSections.forEach((s) => {
-    if (!['Select Customer', 'Customer Details', 'Select Contact', 'Contact Details'].includes(s.label)) {
+    if (!['Select Opportunity From', 'Customer Details', 'Select Contact', 'Contact Details'].includes(s.label)) {
       _filteredSections.push(s)
     }
   })

--- a/next_crm/install.py
+++ b/next_crm/install.py
@@ -135,7 +135,7 @@ def add_default_fields_layout(force=False):
         },
         "Opportunity-Quick Entry": {
             "doctype": "Opportunity",
-            "layout": '[{"label": "Select Customer", "fields": ["customer", "lead", "custom_prospect"], "hideLabel": true, "editable": true}, {"label": "Customer Details", "fields": ["customer_name", "website", "no_of_employees", "territory", "opportunity_amount", "industry"], "hideLabel": true, "editable": true}, {"label": "Select Contact", "fields": ["contact_person"], "hideLabel": true, "editable": true}, {"label": "Contact Details", "fields": ["salutation", "first_name", "last_name", "contact_email", "contact_mobile", "gender"], "hideLabel": true, "editable": true}, {"label": "Other", "columns": 2, "fields": ["status", "opportunity_owner"], "hideLabel": true}]',
+            "layout": '[{"label": "Select Opportunity From", "fields": ["opportunity_from", "party_name"], "hideLabel": true, "editable": true, "columns": 2}, {"label": "Customer Details", "fields": ["customer_name", "website", "no_of_employees", "territory", "opportunity_amount", "industry"], "hideLabel": true, "editable": true}, {"label": "Select Contact", "fields": ["contact_person"], "hideLabel": true, "editable": true}, {"label": "Contact Details", "fields": ["salutation", "first_name", "last_name", "contact_email", "contact_mobile", "gender"], "hideLabel": true, "editable": true}, {"label": "Other", "columns": 2, "fields": ["status", "opportunity_owner"], "hideLabel": true}]',
         },
         "Prospect-Quick Entry": {
             "doctype": "Prospect",

--- a/next_crm/patches.txt
+++ b/next_crm/patches.txt
@@ -12,3 +12,4 @@ next_crm.patches.v1_0.update_crm_settings_lead_contact_creation
 next_crm.patches.v1_0.add_address_sidepanel_layout
 next_crm.patches.v1_0.add_multiple_address_sidepanel_section
 next_crm.patches.v1_0.add_lead_contact_sidepanel_layout
+next_crm.patches.v1_0.modify_opportunity_existing_selection

--- a/next_crm/patches/v1_0/modify_opportunity_existing_selection.py
+++ b/next_crm/patches/v1_0/modify_opportunity_existing_selection.py
@@ -1,0 +1,19 @@
+import json
+
+import frappe
+
+
+def execute():
+    if not frappe.db.exists("CRM Fields Layout", "Opportunity-Quick Entry"):
+        return
+
+    quickentry = frappe.get_doc("CRM Fields Layout", "Opportunity-Quick Entry")
+    parsed_layout = json.loads(quickentry.layout)
+    for section in parsed_layout:
+        if section.get("label") == "Select Customer":
+            section["label"] = "Select Opportunity From"
+            section["fields"] = ["opportunity_from", "party_name"]
+            section["columns"] = 2
+
+    quickentry.layout = json.dumps(parsed_layout)
+    quickentry.save()

--- a/next_crm/patches/v1_0/update_opportunity_quick_entry_layout.py
+++ b/next_crm/patches/v1_0/update_opportunity_quick_entry_layout.py
@@ -14,7 +14,7 @@ def execute():
     layout = json.loads(opportunity)
     for section in layout:
         if section.get("label") in [
-            "Select Customer",
+            "Select Opportunity From",
             "Customer Details",
             "Select Contact",
         ]:


### PR DESCRIPTION
## Description

Currently we have a confusing layout of selecting existing opportunity, lead or customer.
This was because of the lack of Dynamic link support.
Once https://github.com/rtCamp/next-crm/pull/109 is merged we will have necessary changes to instead use the more apt `Opportunity From` and `Party Name` fields instead

## Relevant Technical Choices

1. Earlier there was a redundant check to link with existing customer or prospect, that is removed
2. Opportunity from is directly manipulated from UI now, if not present a prospect is created and opportunity is linked with that instead.
3. Layout is modified for the new flow with patch

## Testing Instructions

- [ ] Run bench migrate to execute the patch
- [ ] The quick entry should be modified with newer layout
- [ ] Check that `party` dynamically filters based on `Opportunity From`
- [ ] Check that both creating from existing and creating from new works as expected

## Additional Information:

Part 2 of https://github.com/rtCamp/next-crm/pull/109

## Screenshot/Screencast

<img width="786" alt="Screenshot 2025-03-25 at 7 25 15 PM" src="https://github.com/user-attachments/assets/289c4e6a-fe02-499e-a120-7d6eec64483c" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
