### PR TITLE
Fix Kanban multiple filters use with column field 'in'

### DIFF
--- a/next_crm/api/doc.py
+++ b/next_crm/api/doc.py
@@ -405,8 +405,10 @@ def get_data(
             ):
                 column_data = []
             else:
-                if not cf_in_filter:
-                    column_filters.update(filters.copy())
+                if cf_in_filter:
+                    filters.pop(column_field, None)
+                column_filters.update(filters.copy())
+
                 page_length = 20
 
                 if kc.get("page_length"):


### PR DESCRIPTION
## Description

Kanban filters doesn't allow multiple filters selection when the `Column Field` is in filters with the `in` scope.
This was due to the complication of merging different filters together overwriting the filter needed to filter each column based on column field.
This can be resolved by ignoring any other `column field` filter when the `in` operator is used as they are redundant.

## Relevant Technical Choices

Pop out the column field key value pair from dictionary when we have a filter on `column field`

## Testing Instructions

- [ ] Open kanban view
- [ ] Test multiple filters combo, involving and without the column field being one of them


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Ref: #74 