### PR TITLE
fix: Uncheck sync button if default google calendar is not found

### DIFF
--- a/frontend/src/components/Activities/AllModals.vue
+++ b/frontend/src/components/Activities/AllModals.vue
@@ -61,6 +61,7 @@ function showToDo(t) {
 }
 
 function showEvent(t) {
+  const user_google_calendar = getUser().google_calendar;
   event.value = t || {
     subtitle: '',
     description: '',
@@ -68,8 +69,8 @@ function showEvent(t) {
     starts_on: '',
     ends_on: '',
     status: 'Open',
-    sync_with_google_calendar: 1,
-    google_calendar: getUser().google_calendar,
+    sync_with_google_calendar: (user_google_calendar ? 1 : 0),
+    google_calendar: user_google_calendar,
   }
   showEventModal.value = true
 }

--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -174,7 +174,7 @@ const _event = ref({
   status: 'Open',
   event_type: 'Private',
   event_category: 'Event',
-  sync_with_google_calendar: true,
+  sync_with_google_calendar: (getUser().google_calendar ? 1 : 0),
   google_calendar: getUser().google_calendar,
 })
 


### PR DESCRIPTION
## Description

- Earlier, `Sync with Google Calendar` used to remain checked when a user tried to create Event from CRM.
- With this PR, sync with Google Calendar will only remain checked by default if there is a default Google Calendar available for that event.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See #111 