### PR TITLE
Update primary contact logic

### DIFF
--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -293,13 +293,6 @@
                             <div class="truncate">
                               {{ contact.full_name }}
                             </div>
-                            <Badge
-                              v-if="contact.is_primary_contact"
-                              class="ml-2"
-                              variant="outline"
-                              :label="__('Primary')"
-                              theme="green"
-                            />
                           </div>
                           <div class="flex items-center">
                             <Dropdown :options="contactOptions(contact)">
@@ -783,14 +776,6 @@ function contactOptions(contact) {
     },
   ]
 
-  if (!contact.is_primary_contact) {
-    options.push({
-      label: __('Set as Primary Contact'),
-      icon: h(SuccessIcon, { class: 'h-4 w-4' }),
-      onClick: () => setPrimaryContact(contact.name),
-    })
-  }
-
   return options
 }
 
@@ -862,22 +847,6 @@ async function removeAddress(address) {
     leadAddresses.reload()
     createToast({
       title: __('Address removed'),
-      icon: 'check',
-      iconClasses: 'text-ink-green-3',
-    })
-  }
-}
-
-async function setPrimaryContact(contact) {
-  let d = await call('next_crm.api.contact.set_primary_contact', {
-    doctype: "Lead",
-    docname: props.leadId,
-    contact,
-  })
-  if (d) {
-    leadContacts.reload()
-    createToast({
-      title: __('Primary contact set'),
       icon: 'check',
       iconClasses: 'text-ink-green-3',
     })

--- a/frontend/src/pages/MobileOpportunity.vue
+++ b/frontend/src/pages/MobileOpportunity.vue
@@ -137,7 +137,7 @@
                                   {{ contact.full_name }}
                                 </div>
                                 <Badge
-                                  v-if="contact.is_primary_contact"
+                                  v-if="contact.name == opportunity.data.contact_person"
                                   class="ml-2"
                                   variant="outline"
                                   :label="__('Primary')"
@@ -558,12 +558,12 @@ async function removeContact(contact) {
 }
 
 async function setPrimaryContact(contact) {
-  let d = await call('next_crm.api.contact.set_primary_contact', {
-    doctype: "Opportunity",
+  let d = await call('next_crm.api.contact.set_opportunity_primary_contact', {
     docname: props.opportunityId,
     contact,
   })
   if (d) {
+    opportunity.reload()
     opportunityContacts.reload()
     createToast({
       title: __('Primary contact set'),

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -242,7 +242,7 @@
                               {{ contact.full_name }}
                             </div>
                             <Badge
-                              v-if="contact.is_primary_contact"
+                              v-if="contact.name == opportunity.data.contact_person"
                               class="ml-2"
                               variant="outline"
                               :label="__('Primary')"
@@ -855,12 +855,12 @@ async function removeAddress(address) {
 }
 
 async function setPrimaryContact(contact) {
-  let d = await call('next_crm.api.contact.set_primary_contact', {
-    doctype: "Opportunity",
+  let d = await call('next_crm.api.contact.set_opportunity_primary_contact', {
     docname: props.opportunityId,
     contact,
   })
   if (d) {
+    opportunity.reload()
     opportunityContacts.reload()
     createToast({
       title: __('Primary contact set'),

--- a/next_crm/api/contact.py
+++ b/next_crm/api/contact.py
@@ -257,23 +257,17 @@ def get_lead_opportunity_contacts(doctype, docname):
 
 
 @frappe.whitelist()
-def set_primary_contact(doctype, docname, contact=None):
-    linked_contacts = get_linked_contact(doctype, docname)
+def set_opportunity_primary_contact(docname, contact=None):
+    linked_contacts = get_linked_contact("Opportunity", docname)
     if not linked_contacts:
         return
 
+    opportunity_doc = frappe.get_doc("Opportunity", docname)
     if not contact and len(linked_contacts) == 1:
-        contact_doc = frappe.get_doc("Contact", linked_contacts[0])
-        contact_doc.is_primary_contact = 1
-        contact_doc.save()
+        opportunity_doc.contact_person = linked_contacts[0]
     elif contact:
-        for linked_contact in linked_contacts:
-            primary = 0
-            if contact == linked_contact:
-                primary = 1
-            frappe.db.set_value(
-                "Contact", linked_contact, "is_primary_contact", primary
-            )
+        opportunity_doc.contact_person = contact
+    opportunity_doc.save()
     return True
 
 

--- a/next_crm/overrides/opportunity.py
+++ b/next_crm/overrides/opportunity.py
@@ -36,7 +36,7 @@ class OverrideOpportunity(Opportunity):
         super().validate()
 
     def after_insert(self):
-        from next_crm.api.contact import set_primary_contact
+        from next_crm.api.contact import set_opportunity_primary_contact
 
         if self.opportunity_from == "Lead":
             link_open_tasks(self.opportunity_from, self.party_name, self)
@@ -47,7 +47,7 @@ class OverrideOpportunity(Opportunity):
                 copy_comments(self.opportunity_from, self.party_name, self)
                 link_communications(self.opportunity_from, self.party_name, self)
         self.set_primary_email_mobile_no()
-        set_primary_contact("Opportunity", self.name)
+        set_opportunity_primary_contact(self.name)
 
     def before_save(self):
         self.apply_sla()

--- a/next_crm/patches/v1_0/migrate_crm_contacts_to_contacts.py
+++ b/next_crm/patches/v1_0/migrate_crm_contacts_to_contacts.py
@@ -26,6 +26,13 @@ def execute():
             link.link_name = crm_contact_doc.parent
             link.link_doctype = crm_contact_doc.parenttype
             link.owner = crm_contact_doc.owner
+            if (
+                crm_contact_doc.is_primary
+                and crm_contact_doc.parenttype == "Opportunity"
+            ):
+                opportunity_doc = frappe.get_doc("Opportunity", crm_contact_doc.parent)
+                opportunity_doc.contact_person = crm_contact_doc.contact
+                opportunity_doc.save()
             link.save()
 
         frappe.db.commit()


### PR DESCRIPTION
## Description

Currently setting a primary contact will set it system wide as it is not per doctype basis but instead globally set in contacts.
This logic can be unintended especially in cases of middle man as primary and can also cause issues where historical data is changed when primary contact is changed.

## Relevant Technical Choices

Primary contact is now set and retrieved based on the `contact_person` field in Opportunity.
Due to the new implementation and original concept of contacts in lead, the primary contact feature is removed from lead again

## Testing Instructions

- [ ] Set contact as primary
- [ ] It should not change primary in other docs
- [ ] Migration patch should also migrate primary

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2163