### PR TITLE
Show toast when converting opportunity eithout organisation name

### DIFF
--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -987,6 +987,16 @@ const existingProspect = ref('')
 
 async function convertToOpportunity() {
 
+  if (!lead.data.company_name) {
+    createToast({
+      title: __('Error'),
+      text: __('Please enter organisation name to create new Prospect'),
+      icon: 'x',
+      iconClasses: 'text-ink-red-4',
+    })
+    return
+  }
+
   if (existingContactChecked.value && !existingContact.value) {
     createToast({
       title: __('Error'),


### PR DESCRIPTION
## Description

When a lead is converted to opportunity we require that `Organisation name` is set so that a new prospect with that name is created.
This currently only shows error in console but instead should create a toast for gracefully exiting.

## Relevant Technical Choices

Show a toast message when converting lead to opportunity

## Testing Instructions

Convert a lead to opportunity with and without organisation name set


## Screenshot/Screencast

<img width="527" alt="Screenshot 2025-03-31 at 2 56 17 PM" src="https://github.com/user-attachments/assets/4ca0d6f9-0a1a-4a01-8cce-b15c3d6d786c" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)