### PR TITLE
Fix primary contact set on opportunity creation

### DIFF
--- a/next_crm/overrides/lead.py
+++ b/next_crm/overrides/lead.py
@@ -201,7 +201,10 @@ class Lead(Lead):
     def create_opportunity(self, contact, customer_or_prospect):
         from erpnext.crm.doctype.lead.lead import make_opportunity
 
-        from next_crm.api.contact import link_contact_to_doc
+        from next_crm.api.contact import (
+            link_contact_to_doc,
+            set_opportunity_primary_contact,
+        )
 
         opportunity = make_opportunity(self.name)
 
@@ -224,6 +227,7 @@ class Lead(Lead):
 
         opportunity.insert()
         link_contact_to_doc(contact, "Opportunity", opportunity.name)
+        set_opportunity_primary_contact(opportunity.name)
         return opportunity.name
 
     def set_sla(self):


### PR DESCRIPTION
## Description

Previously contacts were set primary in after_insert hook but now as the contact linking logic is changed, that hook is rendered useless.
Hence, the logic is shifted into the calling functions.

## Relevant Technical Choices

Primary logic shifted to after contact is linked.

## Testing Instructions

- [ ] Create new opportunity
- [ ] Convert a lead to opportunity
- [ ] The contact should be set as primary.


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)