### PR TITLE
Add doc events to delete opportunity and lead with linked docs

### DIFF
--- a/next_crm/doc_events/lead.py
+++ b/next_crm/doc_events/lead.py
@@ -2,36 +2,55 @@ import frappe
 
 
 def on_trash(doc, method=None):
+    frappe.db.delete("Prospect Lead", filters={"lead": doc.name})
     frappe.db.delete(
         "Dynamic Link",
         filters={"link_name": doc.name, "parenttype": ["in", ["Contact", "Address"]]},
     )
-    frappe.db.delete(
-        "Event",
-        filters=[
-            ["Event Participants", "reference_doctype", "=", "Lead"],
-            ["Event Participants", "reference_docname", "=", doc.name],
-        ],
-    )
-    frappe.db.delete(
-        "Event Participants",
-        filters=[
-            ["reference_doctype", "=", "Lead"],
-            ["reference_docname", "=", doc.name],
-        ],
-    )
+    delete_linked_event(doc.name)
     frappe.db.delete("CRM Notification", {"reference_name": doc.name})
-    gmail_threads = frappe.get_list(
-        "Gmail Thread",
-        filters={
-            "reference_doctype": "Lead",
-            "reference_name": doc.name,
-        },
-        pluck="name",
+    unlink_gmail_thread(doc.name)
+
+
+def delete_linked_event(docname):
+    event_part = frappe.qb.DocType("Event Participants")
+    event_participants_query = (
+        frappe.qb.from_(event_part)
+        .where(event_part.reference_doctype == "Lead")
+        .where(event_part.reference_docname == docname)
+        .select(event_part.parent)
     )
-    for thread in gmail_threads:
-        frappe.db.set_value(
-            "Gmail Thread",
-            thread,
-            {"reference_doctype": None, "reference_name": None, "status": "Open"},
-        )
+
+    event = frappe.qb.DocType("Event")
+    event_delete_query = (
+        frappe.qb.from_(event)
+        .where(event.name.isin(event_participants_query))
+        .delete()
+        .get_sql()
+    )
+
+    event_participants_delete_query = (
+        frappe.qb.from_(event_part)
+        .where(event_part.parent.isin(event_participants_query))
+        .delete()
+        .get_sql()
+    )
+
+    frappe.db.sql(event_delete_query)
+    frappe.db.sql(event_participants_delete_query)
+
+
+def unlink_gmail_thread(docname):
+    gmail_thread = frappe.qb.DocType("Gmail Thread")
+
+    query = (
+        frappe.qb.update(gmail_thread)
+        .set(gmail_thread.reference_doctype, None)
+        .set(gmail_thread.reference_name, None)
+        .set(gmail_thread.status, "Open")
+        .where(gmail_thread.reference_doctype == "Lead")
+        .where(gmail_thread.reference_name == docname)
+        .get_sql()
+    )
+
+    frappe.db.sql(query)

--- a/next_crm/doc_events/lead.py
+++ b/next_crm/doc_events/lead.py
@@ -1,0 +1,39 @@
+import frappe
+
+
+def on_trash(doc, method=None):
+    frappe.db.delete(
+        "Dynamic Link",
+        filters={"link_name": doc.name, "parenttype": ["in", ["Contact", "Address"]]},
+    )
+    events = frappe.get_list(
+        "Event",
+        filters=[
+            ["Event Participants", "reference_doctype", "=", "Lead"],
+            ["Event Participants", "reference_docname", "=", doc.name],
+        ],
+        pluck="name",
+    )
+    frappe.db.delete(
+        "Event Participants",
+        filters=[
+            ["reference_doctype", "=", "Lead"],
+            ["reference_docname", "=", doc.name],
+        ],
+    )
+    frappe.db.delete("Event", {"name": ["in", events]})
+    frappe.db.delete("CRM Notification", {"reference_name": doc.name})
+    gmail_threads = frappe.get_list(
+        "Gmail Thread",
+        filters={
+            "reference_doctype": "Lead",
+            "reference_name": doc.name,
+        },
+        pluck="name",
+    )
+    for thread in gmail_threads:
+        frappe.db.set_value(
+            "Gmail Thread",
+            thread,
+            {"reference_doctype": None, "reference_name": None, "status": "Open"},
+        )

--- a/next_crm/doc_events/lead.py
+++ b/next_crm/doc_events/lead.py
@@ -6,13 +6,12 @@ def on_trash(doc, method=None):
         "Dynamic Link",
         filters={"link_name": doc.name, "parenttype": ["in", ["Contact", "Address"]]},
     )
-    events = frappe.get_list(
+    frappe.db.delete(
         "Event",
         filters=[
             ["Event Participants", "reference_doctype", "=", "Lead"],
             ["Event Participants", "reference_docname", "=", doc.name],
         ],
-        pluck="name",
     )
     frappe.db.delete(
         "Event Participants",
@@ -21,7 +20,6 @@ def on_trash(doc, method=None):
             ["reference_docname", "=", doc.name],
         ],
     )
-    frappe.db.delete("Event", {"name": ["in", events]})
     frappe.db.delete("CRM Notification", {"reference_name": doc.name})
     gmail_threads = frappe.get_list(
         "Gmail Thread",

--- a/next_crm/doc_events/opportunity.py
+++ b/next_crm/doc_events/opportunity.py
@@ -7,32 +7,50 @@ def on_trash(doc, method=None):
         "Dynamic Link",
         filters={"link_name": doc.name, "parenttype": ["in", ["Contact", "Address"]]},
     )
-    frappe.db.delete(
-        "Event",
-        filters=[
-            ["Event Participants", "reference_doctype", "=", "Opportunity"],
-            ["Event Participants", "reference_docname", "=", doc.name],
-        ],
-    )
-    frappe.db.delete(
-        "Event Participants",
-        filters=[
-            ["reference_doctype", "=", "Opportunity"],
-            ["reference_docname", "=", doc.name],
-        ],
-    )
+    delete_linked_event(doc.name)
     frappe.db.delete("CRM Notification", {"reference_name": doc.name})
-    gmail_threads = frappe.get_list(
-        "Gmail Thread",
-        filters={
-            "reference_doctype": "Opportunity",
-            "reference_name": doc.name,
-        },
-        pluck="name",
+    unlink_gmail_thread(doc.name)
+
+
+def delete_linked_event(docname):
+    event_part = frappe.qb.DocType("Event Participants")
+    event_participants_query = (
+        frappe.qb.from_(event_part)
+        .where(event_part.reference_doctype == "Opportunity")
+        .where(event_part.reference_docname == docname)
+        .select(event_part.parent)
     )
-    for thread in gmail_threads:
-        frappe.db.set_value(
-            "Gmail Thread",
-            thread,
-            {"reference_doctype": None, "reference_name": None, "status": "Open"},
-        )
+
+    event = frappe.qb.DocType("Event")
+    event_delete_query = (
+        frappe.qb.from_(event)
+        .where(event.name.isin(event_participants_query))
+        .delete()
+        .get_sql()
+    )
+
+    event_participants_delete_query = (
+        frappe.qb.from_(event_part)
+        .where(event_part.parent.isin(event_participants_query))
+        .delete()
+        .get_sql()
+    )
+
+    frappe.db.sql(event_delete_query)
+    frappe.db.sql(event_participants_delete_query)
+
+
+def unlink_gmail_thread(docname):
+    gmail_thread = frappe.qb.DocType("Gmail Thread")
+
+    query = (
+        frappe.qb.update(gmail_thread)
+        .set(gmail_thread.reference_doctype, None)
+        .set(gmail_thread.reference_name, None)
+        .set(gmail_thread.status, "Open")
+        .where(gmail_thread.reference_doctype == "Opportunity")
+        .where(gmail_thread.reference_name == docname)
+        .get_sql()
+    )
+
+    frappe.db.sql(query)

--- a/next_crm/doc_events/opportunity.py
+++ b/next_crm/doc_events/opportunity.py
@@ -7,13 +7,12 @@ def on_trash(doc, method=None):
         "Dynamic Link",
         filters={"link_name": doc.name, "parenttype": ["in", ["Contact", "Address"]]},
     )
-    events = frappe.get_list(
+    frappe.db.delete(
         "Event",
         filters=[
             ["Event Participants", "reference_doctype", "=", "Opportunity"],
             ["Event Participants", "reference_docname", "=", doc.name],
         ],
-        pluck="name",
     )
     frappe.db.delete(
         "Event Participants",
@@ -22,7 +21,6 @@ def on_trash(doc, method=None):
             ["reference_docname", "=", doc.name],
         ],
     )
-    frappe.db.delete("Event", {"name": ["in", events]})
     frappe.db.delete("CRM Notification", {"reference_name": doc.name})
     gmail_threads = frappe.get_list(
         "Gmail Thread",

--- a/next_crm/doc_events/opportunity.py
+++ b/next_crm/doc_events/opportunity.py
@@ -1,0 +1,40 @@
+import frappe
+
+
+def on_trash(doc, method=None):
+    frappe.db.delete("Prospect Opportunity", filters={"opportunity": doc.name})
+    frappe.db.delete(
+        "Dynamic Link",
+        filters={"link_name": doc.name, "parenttype": ["in", ["Contact", "Address"]]},
+    )
+    events = frappe.get_list(
+        "Event",
+        filters=[
+            ["Event Participants", "reference_doctype", "=", "Opportunity"],
+            ["Event Participants", "reference_docname", "=", doc.name],
+        ],
+        pluck="name",
+    )
+    frappe.db.delete(
+        "Event Participants",
+        filters=[
+            ["reference_doctype", "=", "Opportunity"],
+            ["reference_docname", "=", doc.name],
+        ],
+    )
+    frappe.db.delete("Event", {"name": ["in", events]})
+    frappe.db.delete("CRM Notification", {"reference_name": doc.name})
+    gmail_threads = frappe.get_list(
+        "Gmail Thread",
+        filters={
+            "reference_doctype": "Opportunity",
+            "reference_name": doc.name,
+        },
+        pluck="name",
+    )
+    for thread in gmail_threads:
+        frappe.db.set_value(
+            "Gmail Thread",
+            thread,
+            {"reference_doctype": None, "reference_name": None, "status": "Open"},
+        )

--- a/next_crm/hooks.py
+++ b/next_crm/hooks.py
@@ -169,6 +169,8 @@ doc_events = {
     "User": {
         "before_validate": ["next_crm.api.demo.validate_user"],
     },
+    "Opportunity": {"on_trash": ["next_crm.doc_events.opportunity.on_trash"]},
+    "Lead": {"on_trash": ["next_crm.doc_events.lead.on_trash"]},
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
## Description

Currently Opportunity and Lead are not deletable once they are linked with contact, address, gmail thread, events, prospect, and CRM Notification
This should be allowed.

## Relevant Technical Choices

Doc events are added to execute while deleting which either deletes the links and or the docs to enable deletion of the Lead or Opportunity

## Testing Instructions

- [ ] Link multiple docs to lead or opportunity
- [ ] Attempt to delete them from Next CRM


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes #81 