### PR TITLE
refactor: move doc_events out of API folder

### DIFF
--- a/next_crm/api/comment.py
+++ b/next_crm/api/comment.py
@@ -7,10 +7,6 @@ from frappe import _
 from next_crm.ncrm.doctype.crm_notification.crm_notification import notify_user
 
 
-def on_update(self, method):
-    notify_mentions(self)
-
-
 def notify_mentions(doc):
     """
     Extract mentions from `content`, and notify.

--- a/next_crm/api/contact.py
+++ b/next_crm/api/contact.py
@@ -2,13 +2,6 @@ import frappe
 from frappe import _
 
 
-def validate(doc, method):
-    set_primary_email(doc)
-    set_primary_mobile_no(doc)
-    doc.set_primary_email()
-    doc.set_primary("mobile_no")
-
-
 def set_primary_email(doc):
     if not doc.email_ids:
         return

--- a/next_crm/api/demo.py
+++ b/next_crm/api/demo.py
@@ -23,17 +23,3 @@ def validate_reset_password(user):
             ),
             frappe.PermissionError,
         )
-
-
-def validate_user(doc, event):
-    if (
-        frappe.conf.demo_username
-        and frappe.session.user == frappe.conf.demo_username
-        and doc.new_password
-    ):
-        frappe.throw(
-            _("Password cannot be reset by Demo User {}").format(
-                frappe.bold(frappe.conf.demo_username)
-            ),
-            frappe.PermissionError,
-        )

--- a/next_crm/api/whatsapp.py
+++ b/next_crm/api/whatsapp.py
@@ -7,25 +7,6 @@ from next_crm.api.doc import get_assigned_users
 from next_crm.ncrm.doctype.crm_notification.crm_notification import notify_user
 
 
-def validate(doc, method):
-    if doc.type == "Incoming" and doc.get("from"):
-        name, doctype = get_lead_or_opportunity_from_number(doc.get("from"))
-        doc.reference_doctype = doctype
-        doc.reference_name = name
-
-
-def on_update(doc, method):
-    frappe.publish_realtime(
-        "whatsapp_message",
-        {
-            "reference_doctype": doc.reference_doctype,
-            "reference_name": doc.reference_name,
-        },
-    )
-
-    notify_agent(doc)
-
-
 def notify_agent(doc):
     if doc.type == "Incoming":
         doctype = doc.reference_doctype

--- a/next_crm/doc_events/comment.py
+++ b/next_crm/doc_events/comment.py
@@ -1,0 +1,5 @@
+from next_crm.api.comment import notify_mentions
+
+
+def on_update(doc, method=None):
+    notify_mentions(doc)

--- a/next_crm/doc_events/contact.py
+++ b/next_crm/doc_events/contact.py
@@ -1,0 +1,8 @@
+from next_crm.api.contact import set_primary_email, set_primary_mobile_no
+
+
+def validate(doc, method=None):
+    set_primary_email(doc)
+    set_primary_mobile_no(doc)
+    doc.set_primary_email()
+    doc.set_primary("mobile_no")

--- a/next_crm/doc_events/todo.py
+++ b/next_crm/doc_events/todo.py
@@ -1,0 +1,54 @@
+import frappe
+
+from next_crm.api.todo import notify_assigned_user
+
+
+def before_insert(doc, method=None):
+    from frappe.desk.doctype.notification_log.notification_log import get_title
+
+    if not doc.custom_title and (doc.reference_type and doc.reference_name):
+        title = get_title(doc.reference_type, doc.reference_name)
+        doc.custom_title = title
+
+    if not doc.reference_type == "Task":
+        return
+    ref_doc_desc = frappe.get_value(
+        doc.reference_type, doc.reference_name, "description"
+    )
+    doc.description = ref_doc_desc
+
+
+def after_insert(doc, method=None):
+    if (
+        doc.reference_type in ["Lead", "Opportunity"]
+        and doc.reference_name
+        and doc.allocated_to
+    ):
+        fieldname = (
+            "lead_owner" if doc.reference_type == "Lead" else "opportunity_owner"
+        )
+        lead_owner = frappe.db.get_value(
+            doc.reference_type, doc.reference_name, fieldname
+        )
+        if not lead_owner:
+            frappe.db.set_value(
+                doc.reference_type, doc.reference_name, fieldname, doc.allocated_to
+            )
+
+    if (
+        doc.reference_type in ["Lead", "Opportunity", "ToDo"]
+        and doc.reference_name
+        and doc.allocated_to
+    ):
+        notify_assigned_user(doc)
+
+
+def on_update(doc, method=None):
+    if (
+        doc.has_value_changed("status")
+        and doc.status == "Cancelled"
+        and doc.reference_type in ["Lead", "Opportunity", "ToDo"]
+        and doc.reference_name
+        and doc.allocated_to
+    ):
+        notify_assigned_user(doc, is_cancelled=True)

--- a/next_crm/doc_events/user.py
+++ b/next_crm/doc_events/user.py
@@ -2,7 +2,7 @@ import frappe
 from frappe import _
 
 
-def validate_user(doc, event):
+def before_validate(doc, method=None):
     if (
         frappe.conf.demo_username
         and frappe.session.user == frappe.conf.demo_username

--- a/next_crm/doc_events/user.py
+++ b/next_crm/doc_events/user.py
@@ -1,0 +1,16 @@
+import frappe
+from frappe import _
+
+
+def validate_user(doc, event):
+    if (
+        frappe.conf.demo_username
+        and frappe.session.user == frappe.conf.demo_username
+        and doc.new_password
+    ):
+        frappe.throw(
+            _("Password cannot be reset by Demo User {}").format(
+                frappe.bold(frappe.conf.demo_username)
+            ),
+            frappe.PermissionError,
+        )

--- a/next_crm/doc_events/whatsapp_message.py
+++ b/next_crm/doc_events/whatsapp_message.py
@@ -1,0 +1,22 @@
+import frappe
+
+from next_crm.api.whatsapp import get_lead_or_opportunity_from_number, notify_agent
+
+
+def validate(doc, method=None):
+    if doc.type == "Incoming" and doc.get("from"):
+        name, doctype = get_lead_or_opportunity_from_number(doc.get("from"))
+        doc.reference_doctype = doctype
+        doc.reference_name = name
+
+
+def on_update(doc, method=None):
+    frappe.publish_realtime(
+        "whatsapp_message",
+        {
+            "reference_doctype": doc.reference_doctype,
+            "reference_name": doc.reference_name,
+        },
+    )
+
+    notify_agent(doc)

--- a/next_crm/hooks.py
+++ b/next_crm/hooks.py
@@ -152,22 +152,22 @@ override_doctype_class = {
 
 doc_events = {
     "Contact": {
-        "validate": ["next_crm.api.contact.validate"],
+        "validate": ["next_crm.doc_events.contact.validate"],
     },
     "ToDo": {
-        "after_insert": ["next_crm.api.todo.after_insert"],
-        "on_update": ["next_crm.api.todo.on_update"],
-        "before_insert": ["next_crm.api.todo.before_insert"],
+        "after_insert": ["next_crm.doc_events.todo.after_insert"],
+        "on_update": ["next_crm.doc_events.todo.on_update"],
+        "before_insert": ["next_crm.doc_events.todo.before_insert"],
     },
     "Comment": {
-        "on_update": ["next_crm.api.comment.on_update"],
+        "on_update": ["next_crm.doc_events.comment.on_update"],
     },
     "WhatsApp Message": {
-        "validate": ["next_crm.api.whatsapp.validate"],
-        "on_update": ["next_crm.api.whatsapp.on_update"],
+        "validate": ["next_crm.doc_events.whatsapp_message.validate"],
+        "on_update": ["next_crm.doc_events.whatsapp_message.on_update"],
     },
     "User": {
-        "before_validate": ["next_crm.api.demo.validate_user"],
+        "before_validate": ["next_crm.doc_events.user.validate_user"],
     },
 }
 

--- a/next_crm/hooks.py
+++ b/next_crm/hooks.py
@@ -167,7 +167,7 @@ doc_events = {
         "on_update": ["next_crm.doc_events.whatsapp_message.on_update"],
     },
     "User": {
-        "before_validate": ["next_crm.doc_events.user.validate_user"],
+        "before_validate": ["next_crm.doc_events.user.before_validate"],
     },
 }
 


### PR DESCRIPTION
## Description

Currently doc_events are declared in API folder as well.
This is not in line with the Frappe app skeleton at https://github.com/rtCamp/frappe-skeleton

## Relevant Technical Choices

Moved all `doc_events` from API folder to `doc_events` folder


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)