### PR TITLE
Allow users to set default view

### DIFF
--- a/frontend/src/pages/Leads.vue
+++ b/frontend/src/pages/Leads.vue
@@ -315,6 +315,7 @@ import {
   website,
   formatTime,
 } from '@/utils'
+import { setDefaultViewCache } from '@/utils/view'
 import { Avatar, Tooltip, Dropdown, call } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { ref, computed, reactive, h } from 'vue'
@@ -333,6 +334,15 @@ const defaults = reactive({})
 
 // Create button is shown only with write access
 const hasCreateAccess = ref(false)
+
+let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
+if (!defaultOpenViews) {
+  defaultOpenViews = await setDefaultViewCache()
+}
+
+if (!route.params.viewType && defaultOpenViews.Lead) {
+  route.params.viewType = defaultOpenViews.Lead
+}
 
 call('next_crm.api.doc.check_create_access', {
   doctype: "Lead"

--- a/frontend/src/pages/Opportunities.vue
+++ b/frontend/src/pages/Opportunities.vue
@@ -295,6 +295,7 @@ import {
   formatNumberIntoCurrency,
   formatTime,
 } from '@/utils'
+import { setDefaultViewCache } from '@/utils/view'
 import { Tooltip, Avatar, Dropdown, call } from 'frappe-ui'
 import { useRoute } from 'vue-router'
 import { ref, reactive, computed, h } from 'vue'
@@ -311,6 +312,15 @@ const showOpportunityModal = ref(false)
 const showQuickEntryModal = ref(false)
 
 const defaults = reactive({})
+
+let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
+if (!defaultOpenViews) {
+  defaultOpenViews = await setDefaultViewCache()
+}
+
+if (!route.params.viewType && defaultOpenViews.Opportunity) {
+  route.params.viewType = defaultOpenViews.Opportunity
+}
 
 // Create button is shown only with write access
 const hasCreateAccess = ref(false)

--- a/frontend/src/pages/Prospects.vue
+++ b/frontend/src/pages/Prospects.vue
@@ -72,6 +72,7 @@ import { usersStore } from '@/stores/users'
 import { call } from 'frappe-ui'
 import { dateFormat, dateTooltipFormat, timeAgo, website, formatNumberIntoCurrency } from '@/utils'
 import { ref, reactive, computed, h } from 'vue'
+import { useRoute } from 'vue-router'
 
 const { getUser } = usersStore()
 
@@ -80,6 +81,16 @@ const showProspectModal = ref(false)
 const showQuickEntryModal = ref(false)
 
 const defaults = reactive({})
+const route = useRoute()
+
+let defaultOpenViews = JSON.parse(localStorage.getItem('defaultOpenViews'))
+if (!defaultOpenViews) {
+  defaultOpenViews = await setDefaultViewCache()
+}
+
+if (!route.params.viewType && defaultOpenViews.Prospect) {
+  route.params.viewType = defaultOpenViews.Prospect
+}
 
 // Create button is shown only with write access
 const hasCreateAccess = ref(false)

--- a/frontend/src/pages/ToDos.vue
+++ b/frontend/src/pages/ToDos.vue
@@ -208,11 +208,13 @@ import { usersStore } from '@/stores/users'
 import { dateFormat, dateTooltipFormat, timeAgo } from '@/utils'
 import { Tooltip, Avatar, TextEditor, Dropdown, call } from 'frappe-ui'
 import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
+import { setDefaultViewCache } from '@/utils/view'
 
 const { getUser } = usersStore()
 
 const router = useRouter()
+const route = useRoute()
 
 const todosListView = ref(null)
 
@@ -222,6 +224,15 @@ const loadMore = ref(1)
 const triggerResize = ref(1)
 const updatedPageCount = ref(20)
 const viewControls = ref(null)
+
+let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
+if (!defaultOpenViews) {
+  defaultOpenViews = await setDefaultViewCache()
+}
+
+if (!route.params.viewType && defaultOpenViews.ToDo) {
+  route.params.viewType = defaultOpenViews.ToDo
+}
 
 function getRow(name, field) {
   function getValue(value) {

--- a/frontend/src/utils/view.js
+++ b/frontend/src/utils/view.js
@@ -3,6 +3,7 @@ import GroupByIcon from '@/components/Icons/GroupByIcon.vue'
 import KanbanIcon from '@/components/Icons/KanbanIcon.vue'
 import { viewsStore } from '@/stores/views'
 import { markRaw } from 'vue'
+import { call } from 'frappe-ui'
 
 const { getView: getViewDetails } = viewsStore()
 
@@ -32,4 +33,10 @@ export function getView(view, type, doctype) {
     viewDetails.icon = defaultView(viewType).icon
   }
   return viewDetails || defaultView(viewType)
+}
+
+export async function setDefaultViewCache() {
+   const defaultOpenViews = await call('next_crm.api.views.get_default_open_view')
+   localStorage.setItem("defaultOpenViews", JSON.stringify(defaultOpenViews));
+   return defaultOpenViews
 }

--- a/next_crm/api/views.py
+++ b/next_crm/api/views.py
@@ -30,7 +30,7 @@ def get_default_open_view():
         },
     )
 
-    fallback_views = frappe.get_list(
+    fallback_views = frappe.get_all(
         "CRM View Settings",
         fields=["dt", "type"],
         filters={

--- a/next_crm/api/views.py
+++ b/next_crm/api/views.py
@@ -14,3 +14,39 @@ def get_views(doctype):
         query = query.where(View.dt == doctype)
     views = query.run(as_dict=True)
     return views
+
+
+@frappe.whitelist()
+def get_default_open_view():
+
+    views = frappe.get_list(
+        "CRM View Settings",
+        fields=["dt", "type", "user", "is_default", "default_open_view"],
+        filters={
+            "user": frappe.session.user,
+            "default_open_view": 1,
+            "is_default": 1,
+            "dt": ["is", "set"],
+        },
+    )
+
+    fallback_views = frappe.get_list(
+        "CRM View Settings",
+        fields=["dt", "type"],
+        filters={
+            "user": "",
+            "default_open_view": 1,
+            "is_default": 1,
+            "dt": ["is", "set"],
+        },
+    )
+
+    default_view_object = {}
+    for view in views:
+        default_view_object[view.dt] = view.type
+
+    for view in fallback_views:
+        if not default_view_object[view.dt]:
+            default_view_object[view.dt] = view.type
+
+    return default_view_object

--- a/next_crm/ncrm/doctype/crm_view_settings/crm_view_settings.json
+++ b/next_crm/ncrm/doctype/crm_view_settings/crm_view_settings.json
@@ -1,222 +1,229 @@
 {
- "actions": [],
- "autoname": "autoincrement",
- "creation": "2023-11-27 16:29:10.993403",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "label",
-  "icon",
-  "user",
-  "is_default",
-  "column_break_zacm",
-  "type",
-  "dt",
-  "route_name",
-  "pinned",
-  "public",
-  "filters_tab",
-  "filters",
-  "order_by_tab",
-  "order_by",
-  "list_tab",
-  "list_section",
-  "load_default_columns",
-  "columns",
-  "rows",
-  "group_by_tab",
-  "group_by_field",
-  "kanban_tab",
-  "kanban_section",
-  "column_field",
-  "title_field",
-  "kanban_columns",
-  "kanban_fields"
- ],
- "fields": [
-  {
-   "fieldname": "columns",
-   "fieldtype": "Code",
-   "label": "Columns"
-  },
-  {
-   "fieldname": "user",
-   "fieldtype": "Link",
-   "label": "User",
-   "options": "User"
-  },
-  {
-   "fieldname": "rows",
-   "fieldtype": "Code",
-   "label": "Rows"
-  },
-  {
-   "fieldname": "filters",
-   "fieldtype": "Code",
-   "label": "Filters"
-  },
-  {
-   "fieldname": "filters_tab",
-   "fieldtype": "Tab Break",
-   "label": "Filters"
-  },
-  {
-   "fieldname": "label",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Label"
-  },
-  {
-   "fieldname": "column_break_zacm",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "dt",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "DocType",
-   "options": "DocType"
-  },
-  {
-   "fieldname": "order_by_tab",
-   "fieldtype": "Tab Break",
-   "label": "Order By"
-  },
-  {
-   "fieldname": "order_by",
-   "fieldtype": "Code",
-   "label": "Order By"
-  },
-  {
-   "default": "0",
-   "fieldname": "pinned",
-   "fieldtype": "Check",
-   "label": "Pinned"
-  },
-  {
-   "fieldname": "route_name",
-   "fieldtype": "Data",
-   "label": "Route Name"
-  },
-  {
-   "default": "0",
-   "fieldname": "load_default_columns",
-   "fieldtype": "Check",
-   "label": "Load Default Columns"
-  },
-  {
-   "default": "0",
-   "fieldname": "public",
-   "fieldtype": "Check",
-   "label": "Public"
-  },
-  {
-   "default": "0",
-   "fieldname": "is_default",
-   "fieldtype": "Check",
-   "label": "Is Default"
-  },
-  {
-   "fieldname": "icon",
-   "fieldtype": "Data",
-   "label": "Icon"
-  },
-  {
-   "default": "list",
-   "fieldname": "type",
-   "fieldtype": "Select",
-   "label": "Type",
-   "options": "list\ngroup_by\nkanban"
-  },
-  {
-   "fieldname": "group_by_tab",
-   "fieldtype": "Tab Break",
-   "label": "Group By"
-  },
-  {
-   "fieldname": "group_by_field",
-   "fieldtype": "Data",
-   "label": "Group By Field"
-  },
-  {
-   "fieldname": "list_section",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "kanban_section",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_field",
-   "fieldtype": "Data",
-   "label": "Column Field"
-  },
-  {
-   "fieldname": "list_tab",
-   "fieldtype": "Tab Break",
-   "label": "List"
-  },
-  {
-   "fieldname": "kanban_tab",
-   "fieldtype": "Tab Break",
-   "label": "Kanban"
-  },
-  {
-   "fieldname": "kanban_columns",
-   "fieldtype": "Code",
-   "label": "Kanban Columns"
-  },
-  {
-   "fieldname": "kanban_fields",
-   "fieldtype": "Code",
-   "label": "Kanban Fields"
-  },
-  {
-   "default": "name",
-   "fieldname": "title_field",
-   "fieldtype": "Data",
-   "label": "Title Field"
-  }
- ],
- "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2024-06-25 19:40:12.067788",
- "modified_by": "Administrator",
- "module": "NCRM",
- "name": "CRM View Settings",
- "naming_rule": "Autoincrement",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Sales User",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Sales Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "read_only": 1,
- "sort_field": "modified",
- "sort_order": "DESC",
- "states": [],
- "track_changes": 1
+  "actions": [],
+  "autoname": "autoincrement",
+  "creation": "2023-11-27 16:29:10.993403",
+  "doctype": "DocType",
+  "engine": "InnoDB",
+  "field_order": [
+    "label",
+    "icon",
+    "user",
+    "is_default",
+    "default_open_view",
+    "column_break_zacm",
+    "type",
+    "dt",
+    "route_name",
+    "pinned",
+    "public",
+    "filters_tab",
+    "filters",
+    "order_by_tab",
+    "order_by",
+    "list_tab",
+    "list_section",
+    "load_default_columns",
+    "columns",
+    "rows",
+    "group_by_tab",
+    "group_by_field",
+    "kanban_tab",
+    "kanban_section",
+    "column_field",
+    "title_field",
+    "kanban_columns",
+    "kanban_fields"
+  ],
+  "fields": [
+    {
+      "fieldname": "columns",
+      "fieldtype": "Code",
+      "label": "Columns"
+    },
+    {
+      "fieldname": "user",
+      "fieldtype": "Link",
+      "label": "User",
+      "options": "User"
+    },
+    {
+      "fieldname": "rows",
+      "fieldtype": "Code",
+      "label": "Rows"
+    },
+    {
+      "fieldname": "filters",
+      "fieldtype": "Code",
+      "label": "Filters"
+    },
+    {
+      "fieldname": "filters_tab",
+      "fieldtype": "Tab Break",
+      "label": "Filters"
+    },
+    {
+      "fieldname": "label",
+      "fieldtype": "Data",
+      "in_list_view": 1,
+      "in_standard_filter": 1,
+      "label": "Label"
+    },
+    {
+      "fieldname": "column_break_zacm",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "dt",
+      "fieldtype": "Link",
+      "in_list_view": 1,
+      "in_standard_filter": 1,
+      "label": "DocType",
+      "options": "DocType"
+    },
+    {
+      "fieldname": "order_by_tab",
+      "fieldtype": "Tab Break",
+      "label": "Order By"
+    },
+    {
+      "fieldname": "order_by",
+      "fieldtype": "Code",
+      "label": "Order By"
+    },
+    {
+      "default": "0",
+      "fieldname": "pinned",
+      "fieldtype": "Check",
+      "label": "Pinned"
+    },
+    {
+      "fieldname": "route_name",
+      "fieldtype": "Data",
+      "label": "Route Name"
+    },
+    {
+      "default": "0",
+      "fieldname": "load_default_columns",
+      "fieldtype": "Check",
+      "label": "Load Default Columns"
+    },
+    {
+      "default": "0",
+      "fieldname": "public",
+      "fieldtype": "Check",
+      "label": "Public"
+    },
+    {
+      "default": "0",
+      "fieldname": "is_default",
+      "fieldtype": "Check",
+      "label": "Is Default"
+    },
+    {
+      "fieldname": "icon",
+      "fieldtype": "Data",
+      "label": "Icon"
+    },
+    {
+      "default": "list",
+      "fieldname": "type",
+      "fieldtype": "Select",
+      "label": "Type",
+      "options": "list\ngroup_by\nkanban"
+    },
+    {
+      "fieldname": "group_by_tab",
+      "fieldtype": "Tab Break",
+      "label": "Group By"
+    },
+    {
+      "fieldname": "group_by_field",
+      "fieldtype": "Data",
+      "label": "Group By Field"
+    },
+    {
+      "fieldname": "list_section",
+      "fieldtype": "Section Break"
+    },
+    {
+      "fieldname": "kanban_section",
+      "fieldtype": "Section Break"
+    },
+    {
+      "fieldname": "column_field",
+      "fieldtype": "Data",
+      "label": "Column Field"
+    },
+    {
+      "fieldname": "list_tab",
+      "fieldtype": "Tab Break",
+      "label": "List"
+    },
+    {
+      "fieldname": "kanban_tab",
+      "fieldtype": "Tab Break",
+      "label": "Kanban"
+    },
+    {
+      "fieldname": "kanban_columns",
+      "fieldtype": "Code",
+      "label": "Kanban Columns"
+    },
+    {
+      "fieldname": "kanban_fields",
+      "fieldtype": "Code",
+      "label": "Kanban Fields"
+    },
+    {
+      "default": "name",
+      "fieldname": "title_field",
+      "fieldtype": "Data",
+      "label": "Title Field"
+    },
+    {
+      "default": "0",
+      "fieldname": "default_open_view",
+      "fieldtype": "Check",
+      "label": "Default Open View"
+    }
+  ],
+  "index_web_pages_for_search": 1,
+  "links": [],
+  "modified": "2025-04-10 00:35:28.480813",
+  "modified_by": "Administrator",
+  "module": "NCRM",
+  "name": "CRM View Settings",
+  "naming_rule": "Autoincrement",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "Sales User",
+      "share": 1,
+      "write": 1
+    },
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "export": 1,
+      "print": 1,
+      "read": 1,
+      "report": 1,
+      "role": "Sales Manager",
+      "share": 1,
+      "write": 1
+    }
+  ],
+  "read_only": 1,
+  "sort_field": "modified",
+  "sort_order": "DESC",
+  "states": [],
+  "track_changes": 1
 }


### PR DESCRIPTION
## Description

Currently list views is the default view, but some user might prefer a custom view as default.
This PR allows to select any one of the views as default if they are system pre-defined views.

## Relevant Technical Choices

Added a custom check - "default_open_view" to mark a view as default for a doc.
The default view info is cached to prevent repeated API calls.

## Testing Instructions

- Open any of - Lead, Opportunity, Prospects, ToDo
- Select any view, the current open view will have another action to set as default
- Select that and open the page without the view appended in url


## Screenshot/Screencast

<img width="448" alt="Screenshot 2025-04-10 at 3 33 45 PM" src="https://github.com/user-attachments/assets/329f05a3-7006-4ec9-8674-4cc03cae11b2" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Ref #105 