### PR TITLE
add frontend ui to set address as billing or shipping

### DIFF
--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -792,7 +792,7 @@ function addressOptions(address) {
     options.push({
       label: __('Set as Billing'),
       icon: h(SuccessIcon, { class: 'h-4 w-4' }),
-      onClick: () => setBillingShippingAddress(address.name, true, false),
+      onClick: () => setBillingShippingAddress(address.name, true),
     })
   }
 
@@ -800,7 +800,7 @@ function addressOptions(address) {
     options.push({
       label: __('Set as Shipping'),
       icon: h(SuccessIcon, { class: 'h-4 w-4' }),
-      onClick: () => setBillingShippingAddress(address.name, false, true),
+      onClick: () => setBillingShippingAddress(address.name, false),
     })
   }
 
@@ -855,11 +855,10 @@ async function removeContact(contact) {
   }
 }
 
-async function setBillingShippingAddress(address_name, billing=false, shipping=false) {
+async function setBillingShippingAddress(address_name, is_billing) {
   let d = await call('next_crm.api.address.set_billing_shipping', {
     address_name,
-    billing,
-    shipping,
+    is_billing,
   })
   if (d) {
     leadAddresses.reload()

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -787,6 +787,23 @@ function addressOptions(address) {
       onClick: () => removeAddress(address.name),
     },
   ]
+
+  if (!address.is_primary_address) {
+    options.push({
+      label: __('Set as Billing'),
+      icon: h(SuccessIcon, { class: 'h-4 w-4' }),
+      onClick: () => setBillingShippingAddress(address.name, true, false),
+    })
+  }
+
+  if (!address.is_shipping_address) {
+    options.push({
+      label: __('Set as Shipping'),
+      icon: h(SuccessIcon, { class: 'h-4 w-4' }),
+      onClick: () => setBillingShippingAddress(address.name, false, true),
+    })
+  }
+
   return options
 }
 
@@ -832,6 +849,25 @@ async function removeContact(contact) {
     leadContacts.reload()
     createToast({
       title: __('Contact removed'),
+      icon: 'check',
+      iconClasses: 'text-ink-green-3',
+    })
+  }
+}
+
+async function setBillingShippingAddress(address_name, billing=false, shipping=false) {
+  let d = await call('next_crm.api.address.set_billing_shipping', {
+    address_name,
+    billing,
+    shipping,
+  })
+  if (d) {
+    leadAddresses.reload()
+    let changed = 'Billing'
+    if (shipping)
+      changed = 'Shipping'
+    createToast({
+      title: __(`${changed} address modified`),
       icon: 'check',
       iconClasses: 'text-ink-green-3',
     })

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -789,6 +789,23 @@ function addressOptions(address) {
       onClick: () => removeAddress(address.name),
     },
   ]
+
+  if (!address.is_primary_address) {
+    options.push({
+      label: __('Set as Billing'),
+      icon: h(SuccessIcon, { class: 'h-4 w-4' }),
+      onClick: () => setBillingShippingAddress(address.name, true, false),
+    })
+  }
+
+  if (!address.is_shipping_address) {
+    options.push({
+      label: __('Set as Shipping'),
+      icon: h(SuccessIcon, { class: 'h-4 w-4' }),
+      onClick: () => setBillingShippingAddress(address.name, false, true),
+    })
+  }
+
   return options
 }
 
@@ -848,6 +865,25 @@ async function removeAddress(address) {
     opportunityAddresses.reload()
     createToast({
       title: __('Address removed'),
+      icon: 'check',
+      iconClasses: 'text-ink-green-3',
+    })
+  }
+}
+
+async function setBillingShippingAddress(address_name, billing=false, shipping=false) {
+  let d = await call('next_crm.api.address.set_billing_shipping', {
+    address_name,
+    billing,
+    shipping,
+  })
+  if (d) {
+    opportunityAddresses.reload()
+    let changed = 'Billing'
+    if (shipping)
+      changed = 'Shipping'
+    createToast({
+      title: __(`${changed} address modified`),
       icon: 'check',
       iconClasses: 'text-ink-green-3',
     })

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -794,7 +794,7 @@ function addressOptions(address) {
     options.push({
       label: __('Set as Billing'),
       icon: h(SuccessIcon, { class: 'h-4 w-4' }),
-      onClick: () => setBillingShippingAddress(address.name, true, false),
+      onClick: () => setBillingShippingAddress(address.name, true),
     })
   }
 
@@ -802,7 +802,7 @@ function addressOptions(address) {
     options.push({
       label: __('Set as Shipping'),
       icon: h(SuccessIcon, { class: 'h-4 w-4' }),
-      onClick: () => setBillingShippingAddress(address.name, false, true),
+      onClick: () => setBillingShippingAddress(address.name, false),
     })
   }
 
@@ -871,11 +871,10 @@ async function removeAddress(address) {
   }
 }
 
-async function setBillingShippingAddress(address_name, billing=false, shipping=false) {
+async function setBillingShippingAddress(address_name, is_billing) {
   let d = await call('next_crm.api.address.set_billing_shipping', {
     address_name,
-    billing,
-    shipping,
+    is_billing,
   })
   if (d) {
     opportunityAddresses.reload()

--- a/next_crm/api/address.py
+++ b/next_crm/api/address.py
@@ -55,3 +55,17 @@ def link_address_to_doc(address, doctype, docname):
     address_doc.save()
 
     return address_doc.name
+
+
+@frappe.whitelist()
+def set_billing_shipping(address_name, billing, shipping):
+    address = frappe.get_doc("Address", address_name)
+    if billing:
+        address.is_primary_address = billing
+    elif shipping:
+        address.is_shipping_address = shipping
+    else:
+        return
+
+    address.save()
+    return True

--- a/next_crm/api/address.py
+++ b/next_crm/api/address.py
@@ -58,14 +58,12 @@ def link_address_to_doc(address, doctype, docname):
 
 
 @frappe.whitelist()
-def set_billing_shipping(address_name, billing, shipping):
+def set_billing_shipping(address_name, is_billing):
     address = frappe.get_doc("Address", address_name)
-    if billing:
-        address.is_primary_address = billing
-    elif shipping:
-        address.is_shipping_address = shipping
+    if is_billing:
+        address.is_primary_address = True
     else:
-        return
+        address.is_shipping_address = True
 
     address.save()
     return True

--- a/next_crm/api/lead.py
+++ b/next_crm/api/lead.py
@@ -27,7 +27,14 @@ def get_lead(name):
 def get_lead_addresses(name):
     lead_addresses = frappe.get_list(
         "Address",
-        fields=["address_line1", "phone", "title", "name"],
+        fields=[
+            "address_line1",
+            "phone",
+            "title",
+            "name",
+            "is_primary_address",
+            "is_shipping_address",
+        ],
         filters=[
             ["Dynamic Link", "link_doctype", "=", "Lead"],
             ["Dynamic Link", "link_name", "=", name],

--- a/next_crm/api/opportunity.py
+++ b/next_crm/api/opportunity.py
@@ -34,7 +34,14 @@ def get_opportunity_addresses(name):
 
     opportunity_addresses = frappe.get_list(
         "Address",
-        fields=["address_line1", "phone", "title", "name"],
+        fields=[
+            "address_line1",
+            "phone",
+            "title",
+            "name",
+            "is_primary_address",
+            "is_shipping_address",
+        ],
         filters=[
             [
                 "Dynamic Link",


### PR DESCRIPTION
## Description

Addresses supports setting as billing and shipping but this functionality was neither visible nor changeable from lead or opportunity itself. Current way is to individually open each linked address and check.
Simple badge indicators and actions can be used to make it easier.

## Relevant Technical Choices

Address doc is saved instead of db set as setting a address as billing unsets all other linked address, which is what we wan't.

## Testing Instructions

- [ ] Link multiple address to a opportunity or lead
- [ ] Try setting is as primary billing or shipping
- [ ] Setting one as billing or shipping should unset all other linked addresses

## Screenshot/Screencast

<img width="351" alt="Screenshot 2025-04-11 at 5 34 18 PM" src="https://github.com/user-attachments/assets/8042fa46-3827-4145-9000-f1073767b9c7" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)