### PR TITLE
Use get_all for fetching views

### DIFF
--- a/next_crm/api/views.py
+++ b/next_crm/api/views.py
@@ -19,7 +19,7 @@ def get_views(doctype):
 @frappe.whitelist()
 def get_default_open_view():
 
-    views = frappe.get_list(
+    views = frappe.get_all(
         "CRM View Settings",
         fields=["dt", "type", "user", "is_default", "default_open_view"],
         filters={

--- a/next_crm/ncrm/doctype/crm_view_settings/crm_view_settings.py
+++ b/next_crm/ncrm/doctype/crm_view_settings/crm_view_settings.py
@@ -223,7 +223,7 @@ def create_or_update_default_view(view, set_default_open=False):
 
 
 def reset_default_open_view(doctype):
-    views = frappe.get_list(
+    views = frappe.get_all(
         "CRM View Settings",
         fields="name",
         filters={


### PR DESCRIPTION
## Description

As some users might not have access to `CRM View Settings` this causes pages to break. As the `get_list` query is filtered for users, it should be replaced with `get_all`

## Relevant Technical Choices

change `get_list` to `get_all`

## Testing Instructions

- [ ] Open Next CRM with a user who doesn't explicitly have permissions to see `CRM View Settings`

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)