### PR TITLE
remove suspense from layout pages

### DIFF
--- a/frontend/src/components/Layouts/DesktopLayout.vue
+++ b/frontend/src/components/Layouts/DesktopLayout.vue
@@ -5,9 +5,7 @@
     </div>
     <div class="flex-1 flex flex-col h-full overflow-auto bg-surface-white">
       <AppHeader />
-      <Suspense>
-        <slot />
-      </Suspense>
+      <slot />
     </div>
   </div>
 </template>

--- a/frontend/src/components/Layouts/MobileLayout.vue
+++ b/frontend/src/components/Layouts/MobileLayout.vue
@@ -3,9 +3,7 @@
     <MobileSidebar />
     <div class="flex h-full flex-1 flex-col overflow-auto bg-surface-white">
       <MobileAppHeader />
-      <Suspense>
-        <slot />
-      </Suspense>
+      <slot />
     </div>
   </div>
 </template>

--- a/frontend/src/pages/Address.vue
+++ b/frontend/src/pages/Address.vue
@@ -87,7 +87,7 @@
             theme="gray"
             size="sm"
           >
-            {{ tab.count || 0 }}
+            {{ tab.count }}
           </Badge>
         </button>
       </template>

--- a/frontend/src/pages/Address.vue
+++ b/frontend/src/pages/Address.vue
@@ -191,12 +191,12 @@ const tabs = [
   {
     label: 'Customers',
     icon: h(CustomersIcon, { class: 'h-4 w-4' }),
-    count: computed(() => customers.data?.length),
+    count: computed(() => customers.value.data?.length),
   },
   {
     label: 'Prospects',
     icon: h(ProspectsIcon, { class: 'h-4 w-4' }),
-    count: computed(() => prospects.data?.length),
+    count: computed(() => prospects.value.data?.length),
   },
 ]
 
@@ -228,7 +228,12 @@ async function getCustomersList() {
   return list
 }
 
-const customers = await getCustomersList();
+const customers = ref();
+
+async function setCustomersList() {
+  customers.value = await getCustomersList()
+}
+setCustomersList()
 
 function getCustomerRowObject(customer) {
 
@@ -274,18 +279,22 @@ async function getProspectsList() {
   return list
 }
 
-const prospects = await getProspectsList();
+const prospects = ref();
+
+async function setProspectsList() {
+  prospects.value = await getProspectsList()
+}
+setProspectsList()
 
 const rows = computed(() => {
-  let list = []
+  let list = ref([])
   if (tabIndex.value === 0)
-    list = customers
+    list.value = customers.value
   else if (tabIndex.value === 1)
-    list = prospects
+    list.value = prospects.value
 
-  if (!list.data) return []
-
-  return list.data.map((row) => {
+  if (!list.value.data) return []
+  return list.value.data.map((row) => {
     if (tabIndex.value === 0)
       return getCustomerRowObject(row)
     else if (tabIndex.value === 1)

--- a/frontend/src/pages/Address.vue
+++ b/frontend/src/pages/Address.vue
@@ -87,21 +87,21 @@
             theme="gray"
             size="sm"
           >
-            {{ tab.count }}
+            {{ tab.count || 0 }}
           </Badge>
         </button>
       </template>
       <template #tab-panel="{ tab }">
         <CustomersListView
           class="mt-4"
-          v-if="tab.label === 'Customers' && rows.length"
+          v-if="tab.label === 'Customers' && rows?.length"
           :rows="rows"
           :columns="columns"
           :options="{ selectable: false, showTooltip: false }"
         />
         <ProspectsListView
           class="mt-4"
-          v-if="tab.label === 'Prospects' && rows.length"
+          v-if="tab.label === 'Prospects' && rows?.length"
           :rows="rows"
           :columns="columns"
           :options="{ selectable: false, showTooltip: false }"
@@ -228,7 +228,7 @@ async function getCustomersList() {
   return list
 }
 
-const customers = ref();
+const customers = ref([]);
 
 async function setCustomersList() {
   customers.value = await getCustomersList()
@@ -279,7 +279,7 @@ async function getProspectsList() {
   return list
 }
 
-const prospects = ref();
+const prospects = ref([]);
 
 async function setProspectsList() {
   prospects.value = await getProspectsList()
@@ -293,8 +293,8 @@ const rows = computed(() => {
   else if (tabIndex.value === 1)
     list.value = prospects.value
 
-  if (!list.value.data) return []
-  return list.value.data.map((row) => {
+  if (!list.value?.data) return []
+  return list.value?.data.map((row) => {
     if (tabIndex.value === 0)
       return getCustomerRowObject(row)
     else if (tabIndex.value === 1)

--- a/frontend/src/pages/Customer.vue
+++ b/frontend/src/pages/Customer.vue
@@ -572,21 +572,30 @@ async function getAddressesList() {
   return list
 }
 
-const contacts = ref(await getContactsList());
-const addresses = ref(await getAddressesList());
+const contacts = ref();
+async function setContactsList() {
+  contacts.value = await getContactsList()
+}
+setContactsList()
+
+const addresses = ref();
+async function setAddressesList() {
+  addresses.value = await getAddressesList()
+}
+setAddressesList()
 
 const rows = computed(() => {
-  let list = []
+  let list = ref([])
   if (tabIndex.value === 0)
-    list = opportunities
+    list.value = opportunities
   else if (tabIndex.value === 1)
-    list = contacts.value
+    list.value = contacts.value
   else if (tabIndex.value === 2)
-    list = addresses.value
+    list.value = addresses.value
 
-  if (!list.data) return []
+  if (!list.value.data) return []
 
-  return list.data.map((row) => {
+  return list.value.data.map((row) => {
     if (tabIndex.value === 0)
       return getOpportunityRowObject(row)
     else if (tabIndex.value === 1)

--- a/frontend/src/pages/Leads.vue
+++ b/frontend/src/pages/Leads.vue
@@ -337,7 +337,8 @@ const hasCreateAccess = ref(false)
 
 let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
 if (!defaultOpenViews) {
-  defaultOpenViews = await setDefaultViewCache()
+  defaultOpenViews = setDefaultViewCache()
+  window.location.reload()
 }
 
 if (!route.params.viewType && defaultOpenViews.Lead) {

--- a/frontend/src/pages/MobileAddress.vue
+++ b/frontend/src/pages/MobileAddress.vue
@@ -259,7 +259,7 @@ const tabs = [
     name: 'Customers',
     label: __('Customers'),
     icon: h(CustomersIcon, { class: 'h-4 w-4' }),
-    count: computed(() => customers.data?.length),
+    count: computed(() => customers.value.data?.length),
   },
 ]
 
@@ -293,11 +293,16 @@ async function getCustomersList() {
   return list
 }
 
-const customers = await getCustomersList();
+const customers = ref();
+
+async function setCustomersList() {
+  customers.value = await getCustomersList()
+}
+setCustomersList()
 
 const rows = computed(() => {
-  if (!customers.data || customers.data == []) return []
-  return customers.data.map((row) => getCustomerRowObject(row))
+  if (!customers.value.data || customers.value.data == []) return []
+  return customers.value.data.map((row) => getCustomerRowObject(row))
 })
 
 function getCustomerRowObject(customer) {

--- a/frontend/src/pages/MobileAddress.vue
+++ b/frontend/src/pages/MobileAddress.vue
@@ -79,14 +79,14 @@
           </div>
         </div>
         <CustomersListView
-          v-else-if="tab.label === 'Customers' && rows.length"
+          v-else-if="tab.label === 'Customers' && rows?.length"
           class="mt-4"
           :rows="rows"
           :columns="columns"
           :options="{ selectable: false, showTooltip: false }"
         />
         <div
-          v-if="tab.label === 'Customers' && !rows.length"
+          v-if="tab.label === 'Customers' && !rows?.length"
           class="grid flex-1 place-items-center text-xl font-medium text-ink-gray-4"
         >
           <div class="flex flex-col items-center justify-center space-y-3">
@@ -293,7 +293,7 @@ async function getCustomersList() {
   return list
 }
 
-const customers = ref();
+const customers = ref([]);
 
 async function setCustomersList() {
   customers.value = await getCustomersList()
@@ -301,8 +301,8 @@ async function setCustomersList() {
 setCustomersList()
 
 const rows = computed(() => {
-  if (!customers.value.data || customers.value.data == []) return []
-  return customers.value.data.map((row) => getCustomerRowObject(row))
+  if (!customers.value?.data || customers.value?.data == []) return []
+  return customers.value?.data.map((row) => getCustomerRowObject(row))
 })
 
 function getCustomerRowObject(customer) {

--- a/frontend/src/pages/MobileCustomer.vue
+++ b/frontend/src/pages/MobileCustomer.vue
@@ -402,13 +402,13 @@ const tabs = [
     name: 'Contacts',
     label: __('Contacts'),
     icon: h(ContactsIcon, { class: 'h-4 w-4' }),
-    count: computed(() => contacts.data?.length),
+    count: computed(() => contacts.value.data?.length),
   },
   {
     label: 'Addresses',
     label: __('Addresses'),
     icon: h(AddressIcon, { class: 'h-4 w-4' }),
-    count: computed(() => addresses.data?.length),
+    count: computed(() => addresses.value.data?.length),
   },
 ]
 
@@ -491,21 +491,30 @@ async function getAddressesList() {
   return list
 }
 
-const contacts = await getContactsList();
-const addresses = await getAddressesList();
+const contacts = ref();
+async function setContactsList() {
+  contacts.value = await getContactsList()
+}
+setContactsList()
+
+const addresses = ref();
+async function setAddressesList() {
+  addresses.value = await getAddressesList()
+}
+setAddressesList()
 
 const rows = computed(() => {
-  let list = []
+  let list = ref([])
   if (tabIndex.value === 1)
-    list = opportunities
+    list.value = opportunities
   else if (tabIndex.value === 2)
-    list = contacts
+    list.value = contacts.value
   else if (tabIndex.value === 3)
-    list = addresses
+    list.value = addresses.value
 
-  if (!list.data) return []
+  if (!list.value.data) return []
 
-  return list.data.map((row) => {
+  return list.value.data.map((row) => {
     if (tabIndex.value === 1)
       return getOpportunityRowObject(row)
     else if (tabIndex.value === 2)

--- a/frontend/src/pages/Opportunities.vue
+++ b/frontend/src/pages/Opportunities.vue
@@ -315,7 +315,8 @@ const defaults = reactive({})
 
 let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
 if (!defaultOpenViews) {
-  defaultOpenViews = await setDefaultViewCache()
+  defaultOpenViews = setDefaultViewCache()
+  window.location.reload()
 }
 
 if (!route.params.viewType && defaultOpenViews.Opportunity) {

--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -523,21 +523,30 @@ async function getAddressesList() {
   return list
 }
 
-const contacts = ref(await getContactsList());
-const addresses = ref(await getAddressesList());
+const contacts = ref();
+async function setContactsList() {
+  contacts.value = await getContactsList()
+}
+setContactsList()
+
+const addresses = ref();
+async function setAddressesList() {
+  addresses.value = await getAddressesList()
+}
+setAddressesList()
 
 const rows = computed(() => {
-  let list = []
+  let list = ref([])
   if (tabIndex.value === 0)
-    list = opportunities
+    list.value = opportunities
   else if (tabIndex.value === 1)
-    list = contacts.value
+    list.value = contacts.value
   else if (tabIndex.value === 2)
-    list = addresses.value
+    list.value = addresses.value
 
-  if (!list.data) return []
+  if (!list.value.data) return []
 
-  return list.data.map((row) => {
+  return list.value.data.map((row) => {
     if (tabIndex.value === 0)
       return getOpportunityRowObject(row)
     else if (tabIndex.value === 1)

--- a/frontend/src/pages/Prospects.vue
+++ b/frontend/src/pages/Prospects.vue
@@ -85,7 +85,8 @@ const route = useRoute()
 
 let defaultOpenViews = JSON.parse(localStorage.getItem('defaultOpenViews'))
 if (!defaultOpenViews) {
-  defaultOpenViews = await setDefaultViewCache()
+  defaultOpenViews = setDefaultViewCache()
+  window.location.reload()
 }
 
 if (!route.params.viewType && defaultOpenViews.Prospect) {

--- a/frontend/src/pages/ToDos.vue
+++ b/frontend/src/pages/ToDos.vue
@@ -227,7 +227,8 @@ const viewControls = ref(null)
 
 let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
 if (!defaultOpenViews) {
-  defaultOpenViews = await setDefaultViewCache()
+  defaultOpenViews = setDefaultViewCache()
+  window.location.reload()
 }
 
 if (!route.params.viewType && defaultOpenViews.ToDo) {


### PR DESCRIPTION
## Description

To enable the use of `await` for calls in pages, `suspense` was added to the layouts. This works fine under optimal conditions but sometimes fails drastically, where the URL updates but page doesn't render.
Also, the use of await made loading slower.

All such instances need to be refactored to use reactive variables and async functions to speed up loading and prevent the failures occurring during promise calls.

## Relevant Technical Choices

Removed all `await` usages directly under setup.

## Testing Instructions

- [ ] Check that the errors in navigation are resolved.


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
