### PR TITLE
Fix default view using Vue life cycle hooks

### DIFF
--- a/frontend/src/pages/Leads.vue
+++ b/frontend/src/pages/Leads.vue
@@ -315,10 +315,10 @@ import {
   website,
   formatTime,
 } from '@/utils'
-import { setDefaultViewCache } from '@/utils/view'
+import { getDefaultView } from '@/utils/view'
 import { Avatar, Tooltip, Dropdown, call } from 'frappe-ui'
 import { useRoute } from 'vue-router'
-import { ref, computed, reactive, h } from 'vue'
+import { ref, computed, reactive, h, onBeforeMount, onBeforeUpdate } from 'vue'
 
 const { makeCall } = globalStore()
 const { getUser } = usersStore()
@@ -334,15 +334,6 @@ const defaults = reactive({})
 
 // Create button is shown only with write access
 const hasCreateAccess = ref(false)
-
-let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
-if (!defaultOpenViews) {
-  defaultOpenViews = await setDefaultViewCache()
-}
-
-if (!route.params.viewType && defaultOpenViews.Lead) {
-  route.params.viewType = defaultOpenViews.Lead
-}
 
 call('next_crm.api.doc.check_create_access', {
   doctype: "Lead"
@@ -570,4 +561,7 @@ function showToDo(name) {
   docname.value = name
   showToDoModal.value = true
 }
+
+onBeforeMount(() => getDefaultView("Lead", route))
+onBeforeUpdate(() => getDefaultView("Lead", route))
 </script>

--- a/frontend/src/pages/Opportunities.vue
+++ b/frontend/src/pages/Opportunities.vue
@@ -295,10 +295,10 @@ import {
   formatNumberIntoCurrency,
   formatTime,
 } from '@/utils'
-import { setDefaultViewCache } from '@/utils/view'
+import { getDefaultView } from '@/utils/view'
 import { Tooltip, Avatar, Dropdown, call } from 'frappe-ui'
 import { useRoute } from 'vue-router'
-import { ref, reactive, computed, h } from 'vue'
+import { ref, reactive, computed, h, onBeforeMount, onBeforeUpdate } from 'vue'
 
 const { makeCall } = globalStore()
 const { getUser } = usersStore()
@@ -312,15 +312,6 @@ const showOpportunityModal = ref(false)
 const showQuickEntryModal = ref(false)
 
 const defaults = reactive({})
-
-let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
-if (!defaultOpenViews) {
-  defaultOpenViews = await setDefaultViewCache()
-}
-
-if (!route.params.viewType && defaultOpenViews.Opportunity) {
-  route.params.viewType = defaultOpenViews.Opportunity
-}
 
 // Create button is shown only with write access
 const hasCreateAccess = ref(false)
@@ -553,4 +544,7 @@ function showToDo(name) {
   docname.value = name
   showToDoModal.value = true
 }
+
+onBeforeMount(() => getDefaultView("Opportunity", route))
+onBeforeUpdate(() => getDefaultView("Opportunity", route))
 </script>

--- a/frontend/src/pages/Prospects.vue
+++ b/frontend/src/pages/Prospects.vue
@@ -71,7 +71,8 @@ import ViewControls from '@/components/ViewControls.vue'
 import { usersStore } from '@/stores/users'
 import { call } from 'frappe-ui'
 import { dateFormat, dateTooltipFormat, timeAgo, website, formatNumberIntoCurrency } from '@/utils'
-import { ref, reactive, computed, h } from 'vue'
+import { getDefaultView } from '@/utils/view'
+import { ref, reactive, computed, h, onBeforeMount, onBeforeUpdate } from 'vue'
 import { useRoute } from 'vue-router'
 
 const { getUser } = usersStore()
@@ -82,15 +83,6 @@ const showQuickEntryModal = ref(false)
 
 const defaults = reactive({})
 const route = useRoute()
-
-let defaultOpenViews = JSON.parse(localStorage.getItem('defaultOpenViews'))
-if (!defaultOpenViews) {
-  defaultOpenViews = await setDefaultViewCache()
-}
-
-if (!route.params.viewType && defaultOpenViews.Prospect) {
-  route.params.viewType = defaultOpenViews.Prospect
-}
 
 // Create button is shown only with write access
 const hasCreateAccess = ref(false)
@@ -168,4 +160,7 @@ function parseRows(rows) {
     return _rows
   })
 }
+
+onBeforeMount(() => getDefaultView('Prospect', route))
+onBeforeUpdate(() => getDefaultView('Prospect', route))
 </script>

--- a/frontend/src/pages/ToDos.vue
+++ b/frontend/src/pages/ToDos.vue
@@ -207,9 +207,9 @@ import ToDoModal from '@/components/Modals/ToDoModal.vue'
 import { usersStore } from '@/stores/users'
 import { dateFormat, dateTooltipFormat, timeAgo } from '@/utils'
 import { Tooltip, Avatar, TextEditor, Dropdown, call } from 'frappe-ui'
-import { computed, ref } from 'vue'
+import { computed, ref, onBeforeMount, onBeforeUpdate } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
-import { setDefaultViewCache } from '@/utils/view'
+import { getDefaultView } from '@/utils/view'
 
 const { getUser } = usersStore()
 
@@ -224,15 +224,6 @@ const loadMore = ref(1)
 const triggerResize = ref(1)
 const updatedPageCount = ref(20)
 const viewControls = ref(null)
-
-let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
-if (!defaultOpenViews) {
-  defaultOpenViews = await setDefaultViewCache()
-}
-
-if (!route.params.viewType && defaultOpenViews.ToDo) {
-  route.params.viewType = defaultOpenViews.ToDo
-}
 
 function getRow(name, field) {
   function getValue(value) {
@@ -368,4 +359,7 @@ function redirect(doctype, docname) {
   }
   router.push({ name: name, params: params })
 }
+
+onBeforeMount(() => getDefaultView("ToDo", route))
+onBeforeUpdate(() => getDefaultView("ToDo", route))
 </script>

--- a/frontend/src/utils/view.js
+++ b/frontend/src/utils/view.js
@@ -40,3 +40,14 @@ export async function setDefaultViewCache() {
    localStorage.setItem("defaultOpenViews", JSON.stringify(defaultOpenViews));
    return defaultOpenViews
 }
+
+export async function getDefaultView(doc, route) {
+  let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
+  if (!defaultOpenViews) {
+    defaultOpenViews = await setDefaultViewCache()
+  }
+
+  if ((!route.params.viewType || route.params.viewType == "") && defaultOpenViews[doc]) {
+    route.params.viewType = defaultOpenViews[doc]
+  }
+}


### PR DESCRIPTION
## Description

The default view is setting is not respected when a soft reload of page happens, i.e.m if you are on `leads` and you click `lead` in the sidebar again. As it is not a full remount the setup function doesn't repeat causing pages to fallback to `list`.
This can be fixed by using Vue's lifecycle hooks. Through Lifecycle we can use the before update and before mount hooks.

Thus, the route set function will run whenever the page first loads or subsequently updates instead of just on first load.

## Relevant Technical Choices

Moved default view logic to a separate file for more re-usability across pages and it is now incorporated within lifecycle hooks

## Testing Instructions

- [ ] Open any of - Lead, Opportunity, Prospects, ToDo
- [ ] Select any view, the current open view will have another action to set as default
- [ ] Select that and open the page without the view appended in url
- [ ] Doing soft reload actions such as clicking pinned views or clicking multiple times in sidebar shouldn't change the view

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)