### PR TITLE
change priority of title and name in lead and opportunity

### DIFF
--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -108,9 +108,9 @@
               </component>
             </div>
             <div class="flex flex-col gap-2.5 truncate">
-              <Tooltip :text="lead.data.lead_name || __('Set first name')">
+              <Tooltip :text="lead.data.first_name || __('Set first name')">
                 <div class="truncate text-2xl font-medium text-ink-gray-9" @click="showRenameModal = true">
-                  {{ lead.data.lead_name || lead.data.title || __('Untitled') }}
+                  {{ lead.data.first_name || lead.data.title || lead.data.name || __('Untitled') }}
                 </div>
               </Tooltip>
               <div class="flex gap-1.5">
@@ -751,7 +751,7 @@ const breadcrumbs = computed(() => {
   }
 
   items.push({
-    label: lead.data.lead_name || lead.data.title || __('Untitled'),
+    label: lead.data.title || lead.data.name || __('Untitled'),
     route: { name: 'Lead', params: { leadId: lead.data.name } },
   })
   return items
@@ -759,7 +759,7 @@ const breadcrumbs = computed(() => {
 
 usePageMeta(() => {
   return {
-    title: lead.data?.lead_name || lead.data?.name,
+    title: lead.data.title || lead.data?.name || lead.data?.name,
   }
 })
 

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -662,7 +662,7 @@ const breadcrumbs = computed(() => {
   }
 
   items.push({
-    label: customer.data?.name || opportunity.data?.title || opportunity.data?.party_name || __('Untitled'),
+    label: opportunity.data?.title || customer.data?.name || opportunity.data?.party_name || __('Untitled'),
     route: { name: 'Opportunity', params: { opportunityId: opportunity.data.name } },
   })
   return items
@@ -670,7 +670,7 @@ const breadcrumbs = computed(() => {
 
 usePageMeta(() => {
   return {
-    title: customer.data?.name || opportunity.data?.party_name || opportunity.data?.name,
+    title: opportunity.data?.title || customer.data?.name || opportunity.data?.party_name || opportunity.data?.name,
   }
 })
 


### PR DESCRIPTION
## Description

Currently in Lead the `lead name` and in Opportunity the `Customer name` have the highest priority for title in breadcrumb and page title.
As we also have a `title` field it is better to give highest priority allocation to it instead.

## Relevant Technical Choices

Changed priority allocation and fallback order for title and page title

## Testing Instructions

- [ ] Change title or set title of a doc
- [ ] Check that that title should be the one visible irrespective of customer name, etc...


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)