### PR TITLE
set icon as None if not a string

### DIFF
--- a/next_crm/ncrm/doctype/crm_view_settings/crm_view_settings.py
+++ b/next_crm/ncrm/doctype/crm_view_settings/crm_view_settings.py
@@ -34,7 +34,7 @@ def create(view):
     doc.name = view.label
     doc.label = view.label
     doc.type = view.type or "list"
-    doc.icon = view.icon
+    doc.icon = view.icon if isinstance(view.icon, str) else None
     doc.dt = view.doctype
     doc.user = frappe.session.user
     doc.route_name = view.route_name or ""
@@ -69,7 +69,7 @@ def update(view):
     doc = frappe.get_doc("CRM View Settings", view.name)
     doc.label = view.label
     doc.type = view.type or "list"
-    doc.icon = view.icon
+    doc.icon = view.icon if isinstance(view.icon, str) else None
     doc.route_name = view.route_name or ""
     doc.load_default_columns = view.load_default_columns or False
     doc.filters = json.dumps(filters)


### PR DESCRIPTION
## Description

In rare cases a dictionary / object is passed for view icon instead of a string value. This causes issue in saving the view.
The data type of value can be checked and if it is not a string then we should pass `None` to have no icon instead.


## Testing Instructions

- [ ] Try to pass a non string icon to backend
- [ ] Check that it should still work and set none instead


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes: https://github.com/rtCamp/erp-rtcamp/issues/2197