### PR TITLE
fix: update GitHub workflow runners based on repo visibility

### DIFF
--- a/.github/workflows/vulnerable_dependency_check.yml
+++ b/.github/workflows/vulnerable_dependency_check.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   deps-vulnerable-check:
     name: Vulnerable Dependency Check
-    runs-on: ["self-hosted", "python"]
+    runs-on: ubuntu-latest
     container:
       image: python:latest
     defaults:


### PR DESCRIPTION
This pull request updates the workflow configuration for the vulnerable dependency check job to use a different runner.

Workflow configuration update:

* [`.github/workflows/vulnerable_dependency_check.yml`](diffhunk://#diff-a8262a29ff02068a209969128488c5e574b998bb23be4ed91b4e4e421e843828L17-R17): Changed the `runs-on` parameter from `["self-hosted", "python"]` to `ubuntu-latest`, ensuring the job runs on a GitHub-hosted runner instead of a self-hosted one.