### PR TITLE
Fix notifications redirect and text

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <Layout v-if="session().isLoggedIn">
-    <router-view />
+    <router-view :key="routeKey"/>
   </Layout>
   <Dialogs />
   <Toasts />
@@ -11,6 +11,15 @@ import { Dialogs } from '@/utils/dialogs'
 import { sessionStore as session } from '@/stores/session'
 import { Toasts, setConfig } from 'frappe-ui'
 import { computed, defineAsyncComponent } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
+
+const routeKey = computed(() => {
+  if (route.name === 'Lead') return route.params.leadId
+  if (route.name === 'Opportunity') return route.params.opportunityId
+  return route.fullPath
+})
 
 const MobileLayout = defineAsyncComponent(() =>
   import('./components/Layouts/MobileLayout.vue')

--- a/next_crm/api/comment.py
+++ b/next_crm/api/comment.py
@@ -23,7 +23,7 @@ def notify_mentions(doc):
         if doctype.startswith("CRM "):
             doctype = doctype[4:].lower()
         name = (
-            reference_doc.lead_name or None
+            reference_doc.title or reference_doc.name or None
             if doctype == "Lead"
             else reference_doc.party_name or None
         )

--- a/next_crm/api/todo.py
+++ b/next_crm/api/todo.py
@@ -39,15 +39,19 @@ def notify_assigned_user(doc, is_cancelled=False):
 def get_notification_text(owner, doc, reference_doc, is_cancelled=False):
     name = doc.reference_name
     doctype = doc.reference_type
+    doc_doctype = doc.doctype
 
     if doctype.startswith("CRM "):
         doctype = doctype[4:].lower()
 
-    if doctype in ["lead", "opportunity"]:
+    if (
+        doctype in ["Lead", "Opportunity"]
+        and doc.allocated_to not in reference_doc._assign
+    ):
         name = (
-            reference_doc.lead_name or name
-            if doctype == "lead"
-            else reference_doc.customer or reference_doc.lead_name or name
+            reference_doc.title or name
+            if doctype == "Lead"
+            else reference_doc.title or reference_doc.customer or name
         )
 
         if is_cancelled:
@@ -71,12 +75,12 @@ def get_notification_text(owner, doc, reference_doc, is_cancelled=False):
 			</div>
 		"""
 
-    if doctype == "ToDo":
+    if doc_doctype == "ToDo":
         if is_cancelled:
             return f"""
 				<div class="mb-2 leading-5 text-ink-gray-5">
 					<span>{ _('Your assignment on ToDo {0} has been removed by {1}').format(
-						f'<span class="font-medium text-ink-gray-9">{ reference_doc.title }</span>',
+						f'<span class="font-medium text-ink-gray-9">{ reference_doc.title or reference_doc.name }</span>',
 						f'<span class="font-medium text-ink-gray-9">{ owner }</span>'
 					) }</span>
 				</div>
@@ -84,8 +88,9 @@ def get_notification_text(owner, doc, reference_doc, is_cancelled=False):
         return f"""
 			<div class="mb-2 leading-5 text-ink-gray-5">
 				<span class="font-medium text-ink-gray-9">{ owner }</span>
-				<span>{ _('assigned a new ToDo {0} to you').format(
-					f'<span class="font-medium text-ink-gray-9">{ reference_doc.title }</span>'
+				<span>{ _('assigned a new ToDo in {0} {1} to you').format(
+                    doctype,
+					f'<span class="font-medium text-ink-gray-9">{ reference_doc.title or reference_doc.name }</span>'
 				) }</span>
 			</div>
 		"""

--- a/next_crm/api/todo.py
+++ b/next_crm/api/todo.py
@@ -44,9 +44,8 @@ def get_notification_text(owner, doc, reference_doc, is_cancelled=False):
     if doctype.startswith("CRM "):
         doctype = doctype[4:].lower()
 
-    if (
-        doctype in ["Lead", "Opportunity"]
-        and doc.allocated_to not in reference_doc._assign
+    if doctype in ["Lead", "Opportunity"] and (
+        doc.allocated_to not in reference_doc._assign if reference_doc._assign else True
     ):
         name = (
             reference_doc.title or name
@@ -57,21 +56,22 @@ def get_notification_text(owner, doc, reference_doc, is_cancelled=False):
         if is_cancelled:
             return f"""
 				<div class="mb-2 leading-5 text-ink-gray-5">
-					<span>{ _('Your assignment on {0} {1} has been removed by {2}').format(
-						doctype,
-						f'<span class="font-medium text-ink-gray-9">{ name }</span>',
-						f'<span class="font-medium text-ink-gray-9">{ owner }</span>'
-					) }</span>
+					<span>{
+                _("Your assignment on {0} {1} has been removed by {2}").format(
+                    doctype,
+                    f'<span class="font-medium text-ink-gray-9">{name}</span>',
+                    f'<span class="font-medium text-ink-gray-9">{owner}</span>',
+                )
+            }</span>
 				</div>
 			"""
 
         return f"""
 			<div class="mb-2 leading-5 text-ink-gray-5">
-				<span class="font-medium text-ink-gray-9">{ owner }</span>
-				<span>{ _('assigned a {0} {1} to you').format(
-					doctype,
-					f'<span class="font-medium text-ink-gray-9">{ name }</span>'
-				) }</span>
+				<span class="font-medium text-ink-gray-9">{owner}</span>
+				<span>{
+            _("assigned a {0} {1} to you").format(doctype, f'<span class="font-medium text-ink-gray-9">{name}</span>')
+        }</span>
 			</div>
 		"""
 
@@ -79,19 +79,22 @@ def get_notification_text(owner, doc, reference_doc, is_cancelled=False):
         if is_cancelled:
             return f"""
 				<div class="mb-2 leading-5 text-ink-gray-5">
-					<span>{ _('Your assignment on ToDo {0} has been removed by {1}').format(
-						f'<span class="font-medium text-ink-gray-9">{ reference_doc.title or reference_doc.name }</span>',
-						f'<span class="font-medium text-ink-gray-9">{ owner }</span>'
-					) }</span>
+					<span>{
+                _("Your assignment on ToDo {0} has been removed by {1}").format(
+                    f'<span class="font-medium text-ink-gray-9">{reference_doc.title or reference_doc.name}</span>',
+                    f'<span class="font-medium text-ink-gray-9">{owner}</span>',
+                )
+            }</span>
 				</div>
 			"""
         return f"""
 			<div class="mb-2 leading-5 text-ink-gray-5">
-				<span class="font-medium text-ink-gray-9">{ owner }</span>
-				<span>{ _('assigned a new ToDo in {0} {1} to you').format(
-                    doctype,
-					f'<span class="font-medium text-ink-gray-9">{ reference_doc.title or reference_doc.name }</span>'
-				) }</span>
+				<span class="font-medium text-ink-gray-9">{owner}</span>
+				<span>{
+            _("assigned a new ToDo in {0} {1} to you").format(
+                doctype, f'<span class="font-medium text-ink-gray-9">{reference_doc.title or reference_doc.name}</span>'
+            )
+        }</span>
 			</div>
 		"""
 


### PR DESCRIPTION
## Description

Notification redirects fails when you click on one of `Opportunity` when you already have a `Opportunity` opened. The same is true for `Lead` as well.
This is because Vue doesn't remount the component and tries to reuse it. This can be fixed by forcing Vue to re-render it by utilising key values.

Also, notification text showed Lead as none when using comments and assignment of Doc and ToDo showed text of mention instead of assignment.

## Relevant Technical Choices

Added key value to router view to make components distinct based on key, making it possible for Vue to know when to re-render the component

## Testing Instructions

- [ ] Notifications should redirect even when on same doctype
- [ ] Notification should show assignment for doc when you first create a ToDo and user not in assignment
- [ ] Notification will instead show assignment to ToDo when user already in assign list


## Screenshot/Screencast


https://github.com/user-attachments/assets/60ca71d2-58b5-4ff5-a1c3-4cfc354fd7c6



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes: https://github.com/rtCamp/erp-rtcamp/issues/2190