### PR TITLE
remove await from setup in event modal

### DIFF
--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -174,31 +174,26 @@ const _event = ref({
   status: 'Open',
   event_type: 'Private',
   event_category: 'Event',
-  sync_with_google_calendar: (getUser().google_calendar ? 1 : 0),
+  sync_with_google_calendar: getUser().google_calendar ? 1 : 0,
   google_calendar: getUser().google_calendar,
 })
 
-const eventMeta = ref(
-  await call('next_crm.api.doc.get_fields_meta', {
-    doctype: 'Event',
-  }),
-)
+const eventTypeOptions = ref({})
+const eventCategoryOptions = ref({})
+const eventMeta = ref({})
+updateEventMeta()
 
-let eventTypeOptions = eventMeta.value.event_type.options.split('\n')
-let eventCategoryOptions = eventMeta.value.event_category.options.split('\n')
+async function updateEventMeta() {
+  eventMeta.value = await call('next_crm.api.doc.get_fields_meta', {
+    doctype: 'Event',
+  })
+  eventTypeOptions.value = eventMeta.value.event_type.options.split('\n')
+  eventCategoryOptions.value = eventMeta.value.event_category.options.split('\n')
+}
 
 function updateEventStatus(status) {
   _event.value.status = status
 }
-
-const fields = createResource({
-  url: 'next_crm.api.doc.get_fields_meta',
-  params: { doctype: 'Event' },
-  auto: true,
-  onSuccess: (data) => {
-    data
-  },
-})
 
 async function updateEvent() {
   if (!_event.value.subject) {


### PR DESCRIPTION
## Description

Events modal was still using await calls which caused failure as suspense was removed earlier allowing this.
Due to which the modal fails silently.
This can be fixed by moving await calls into async functions and utilising reactive variables.

## Testing Instructions

- [ ] Open new event modal
- [ ] Create a new event


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
