### PR TITLE
Don't add client email in event participants and give option to add participants manually.

### DIFF
--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -242,7 +242,6 @@ async function updateEvent() {
       events.value.reload()
     }
   } else {
-    console.log(event_participants.value)
     let doc = {
       doctype: 'Event',
       reference_type: props.doctype,

--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -136,7 +136,7 @@
             :validate="validate"
             :error="(value) => !validate(value)"
             :hideMe="true"
-            :triggerKeys="['Enter', ',', 'Tab', ' ']"
+            :triggerKeys="['Enter', ',', 'Tab', ' ', 'ArrowRight']"
           ></MultiValueInput>
         </div>
       </div>

--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -233,6 +233,18 @@ async function updateEvent() {
   }
   _event.value.assigned_by = getUser().name
   if (_event.value.name) {
+    _event.value.event_participants = _event.value.event_participants.filter(
+      (participant) => participant.reference_doctype !== 'User' || participant.reference_docname !== 'Guest',
+    )
+    _event.value.event_participants = [
+      ..._event.value.event_participants,
+      ...event_participants.value.map((email) => ({
+        reference_doctype: 'User',
+        reference_docname: 'Guest',
+        email: email,
+      })),
+    ]
+
     let d = await call('frappe.client.set_value', {
       doctype: 'Event',
       name: _event.value.name,
@@ -279,6 +291,12 @@ function render() {
     _event.value = { ...props.event }
     if (_event.value.subject) {
       editMode.value = true
+      // get event_participants from event, if any
+      event_participants.value = (_event.value.event_participants || [])
+        .filter((participant) => participant.reference_doctype === 'User' && participant.reference_docname === 'Guest')
+        .map((participant) => participant.email)
+    } else {
+      event_participants.value = []
     }
   })
 }

--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -126,6 +126,19 @@
           >
           </Link>
         </div>
+        <div class="flex flex-wrap items-center gap-2 w-full" v-if="_event.sync_with_google_calendar">
+          <!-- Multi input to enter email addresses for event participants. -->
+          <MultiValueInput
+            v-model="event_participants"
+            class="flex-grow"
+            :placeholder="__('Add participants')"
+            :errorMessage="(value) => __('Invalid email address: {0}', [value])"
+            :validate="validate"
+            :error="(value) => !validate(value)"
+            :hideMe="true"
+            :triggerKeys="['Enter', ',', 'Tab', ' ']"
+          ></MultiValueInput>
+        </div>
       </div>
     </template>
   </Dialog>
@@ -135,11 +148,16 @@
 import EventStatusIcon from '@/components/Icons/EventStatusIcon.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import Link from '@/components/Controls/Link.vue'
+import MultiValueInput from '../Controls/MultiValueInput.vue'
 import { eventStatusOptions, createToast } from '@/utils'
 import { usersStore } from '@/stores/users'
 import { capture } from '@/telemetry'
 import { TextEditor, Dropdown, FormControl, Tooltip, call, DateTimePicker, createResource } from 'frappe-ui'
 import { ref, watch, nextTick, onMounted } from 'vue'
+
+function validate(value) {
+  return /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(value)
+}
 
 const props = defineProps({
   event: {
@@ -177,6 +195,8 @@ const _event = ref({
   sync_with_google_calendar: getUser().google_calendar ? 1 : 0,
   google_calendar: getUser().google_calendar,
 })
+
+const event_participants = ref([])
 
 const eventTypeOptions = ref({})
 const eventCategoryOptions = ref({})
@@ -222,30 +242,32 @@ async function updateEvent() {
       events.value.reload()
     }
   } else {
-    let d = await call('frappe.client.insert', {
-      doc: {
-        doctype: 'Event',
-        reference_type: props.doctype,
-        reference_name: props.doc || null,
-        ..._event.value,
-      },
-    })
-    if (d.name) {
-      let participants = await call('frappe.client.insert', {
-        doc: {
-          doctype: 'Event Participants',
-          parent: d.name,
+    console.log(event_participants.value)
+    let doc = {
+      doctype: 'Event',
+      reference_type: props.doctype,
+      reference_name: props.doc || null,
+      event_participants: [
+        {
           reference_doctype: props.doctype,
           reference_docname: props.doc || null,
-          parentfield: 'event_participants',
-          parenttype: 'Event',
+          email: getUser().email,
         },
-      })
-      if (participants.name) {
-        capture('event_created')
-        events.value.reload()
-        emit('after')
-      }
+        ...event_participants.value.map((email) => ({
+          reference_doctype: 'User',
+          reference_docname: 'Guest',
+          email: email,
+        })),
+      ],
+      ..._event.value,
+    }
+    let d = await call('frappe.client.insert', {
+      doc: doc,
+    })
+    if (d.name) {
+      capture('event_created')
+      events.value.reload()
+      emit('after')
     }
   }
   show.value = false

--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -511,6 +511,13 @@ def get_linked_events(name):
         ],
     )
 
+    for event in events:
+        event["event_participants"] = frappe.db.get_all(
+            "Event Participants",
+            filters={"parent": event.name},
+            fields=["reference_doctype", "reference_docname", "email"],
+        )
+
     return events or []
 
 


### PR DESCRIPTION
## Description

<!-- What do we want to achieve with this PR? -->

## Relevant Technical Choices

- Ref: https://github.com/rtCamp/erp-rtcamp/issues/2206#issuecomment-2830626441

## Testing Instructions

- [ ] Check if event is being created.
- [ ] Confirm that client is not being included in the event participants.
- [ ] Check you can add participants in event from Next CRM.
- [ ] Check that you can update participants in an existing event from Next CRM.

## Additional Information:

- Instead of client email, email of the user creating the event will be added instead.
- Updated `MultiValueInput.vue` to resolve issues with the input box.
- The values can be separated with either `Tab`, `Enter`, `,` or ` ` (space) when entering value in email participants.

## Screenshot/Screencast

<img width="575" alt="image" src="https://github.com/user-attachments/assets/48d33b7f-85c0-40f6-a0df-ca1884fbfc56" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2206