### PR TITLE
Only show contacts and address belonging to opportunity

### DIFF
--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -863,7 +863,7 @@ async function setBillingShippingAddress(address_name, is_billing) {
   if (d) {
     leadAddresses.reload()
     let changed = 'Billing'
-    if (shipping)
+    if (!is_billing)
       changed = 'Shipping'
     createToast({
       title: __(`${changed} address modified`),
@@ -874,8 +874,9 @@ async function setBillingShippingAddress(address_name, is_billing) {
 }
 
 async function removeAddress(address) {
-  let d = await call('next_crm.api.lead.remove_address', {
-    opportunity: props.leadId,
+  let d = await call('next_crm.api.address.remove_address', {
+    link_doctype: "Lead",
+    link_name: props.leadId,
     address,
   })
   if (d) {
@@ -905,8 +906,8 @@ const leadContacts = createResource({
 })
 
 const leadAddresses = createResource({
-  url: '/api/method/next_crm.api.lead.get_lead_addresses',
-  params: { name: props.leadId },
+  url: '/api/method/next_crm.api.address.get_linked_address',
+  params: { link_doctype: "Lead", link_name: props.leadId },
   cache: ['lead_addresses', props.leadId],
   auto: true,
   transform: (data) => {

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -860,8 +860,9 @@ async function removeContact(contact) {
 }
 
 async function removeAddress(address) {
-  let d = await call('next_crm.api.opportunity.remove_address', {
-    opportunity: props.opportunityId,
+  let d = await call('next_crm.api.address.remove_address', {
+    link_doctype: "Opportunity",
+    link_name: props.opportunityId,
     address,
   })
   if (d) {
@@ -882,7 +883,7 @@ async function setBillingShippingAddress(address_name, is_billing) {
   if (d) {
     opportunityAddresses.reload()
     let changed = 'Billing'
-    if (shipping)
+    if (!is_billing)
       changed = 'Shipping'
     createToast({
       title: __(`${changed} address modified`),
@@ -925,8 +926,8 @@ const opportunityContacts = createResource({
 })
 
 const opportunityAddresses = createResource({
-  url: '/api/method/next_crm.api.opportunity.get_opportunity_addresses',
-  params: { name: props.opportunityId },
+  url: '/api/method/next_crm.api.address.get_linked_address',
+  params: { link_doctype: "Opportunity", link_name: props.opportunityId },
   cache: ['opportunity_addresses', props.opportunityId],
   auto: true,
   transform: (data) => {

--- a/next_crm/api/contact.py
+++ b/next_crm/api/contact.py
@@ -169,7 +169,7 @@ def get_linked_contact(link_doctype, link_name):
     link_doctypes = [link_doctype]
     if link_doctype == "Opportunity":
         opportunity = frappe.get_cached_doc("Opportunity", link_name)
-        if opportunity.opportunity_from:
+        if opportunity.opportunity_from and opportunity.opportunity_from == "Lead":
             link_doctypes.append(opportunity.opportunity_from)
             link_names.append(opportunity.party_name)
 

--- a/next_crm/api/lead.py
+++ b/next_crm/api/lead.py
@@ -21,37 +21,3 @@ def get_lead(name):
     lead["_form_script"] = get_form_script("Lead")
     lead["_assign"] = get_assigned_users("Lead", lead.name)
     return lead
-
-
-@frappe.whitelist()
-def get_lead_addresses(name):
-    lead_addresses = frappe.get_list(
-        "Address",
-        fields=[
-            "address_line1",
-            "phone",
-            "title",
-            "name",
-            "is_primary_address",
-            "is_shipping_address",
-        ],
-        filters=[
-            ["Dynamic Link", "link_doctype", "=", "Lead"],
-            ["Dynamic Link", "link_name", "=", name],
-        ],
-        distinct=True,
-    )
-    return lead_addresses
-
-
-@frappe.whitelist()
-def remove_address(lead, address):
-    if not frappe.has_permission("Lead", "write", lead):
-        frappe.throw(
-            _("Not allowed to remove address from Lead"), frappe.PermissionError
-        )
-
-    address_doc = frappe.get_doc("Address", address)
-    address_doc.links = [d for d in address_doc.links if d.link_name != lead]
-    address_doc.save()
-    return True

--- a/next_crm/api/opportunity.py
+++ b/next_crm/api/opportunity.py
@@ -29,34 +29,6 @@ def get_opportunity(name):
 
 
 @frappe.whitelist()
-def get_opportunity_addresses(name):
-    opportunity = frappe.get_cached_doc("Opportunity", name)
-
-    opportunity_addresses = frappe.get_list(
-        "Address",
-        fields=[
-            "address_line1",
-            "phone",
-            "title",
-            "name",
-            "is_primary_address",
-            "is_shipping_address",
-        ],
-        filters=[
-            [
-                "Dynamic Link",
-                "link_doctype",
-                "in",
-                ["Opportunity", opportunity.opportunity_from],
-            ],
-            ["Dynamic Link", "link_name", "in", [name, opportunity.party_name]],
-        ],
-        distinct=True,
-    )
-    return opportunity_addresses
-
-
-@frappe.whitelist()
 def add_address(opportunity, address):
     if not frappe.has_permission("Opportunity", "write", opportunity):
         frappe.throw(
@@ -83,27 +55,13 @@ def add_address(opportunity, address):
 
 
 @frappe.whitelist()
-def remove_address(opportunity, address):
-    if not frappe.has_permission("Opportunity", "write", opportunity):
-        frappe.throw(
-            _("Not allowed to remove address from Opportunity"), frappe.PermissionError
-        )
-
-    opportunity_doc = frappe.get_cached_doc("Opportunity", opportunity)
-    address_doc = frappe.get_doc("Address", address)
-    link_names = [opportunity]
-    if opportunity_doc.opportunity_from:
-        link_names.append(opportunity_doc.party_name)
-    address_doc.links = [d for d in address_doc.links if d.link_name not in link_names]
-    address_doc.save()
-    return True
-
-@frappe.whitelist()
-def declare_enquiry_lost_api(name, lost_reasons_list, competitors, detailed_reason=None):
+def declare_enquiry_lost_api(
+    name, lost_reasons_list, competitors, detailed_reason=None
+):
     opportunity = frappe.get_doc("Opportunity", name)
     opportunity.declare_enquiry_lost(
         lost_reasons_list=lost_reasons_list,
         competitors=competitors,
-        detailed_reason=detailed_reason
+        detailed_reason=detailed_reason,
     )
     return _("Opportunity updated successfully")


### PR DESCRIPTION
## Description

Currently opportunity shows all contacts and addresses linked to the opportunity and it's associated doc like Customer, Prospect, Lead.

This is not ideal and should only show that Opportunities and any linked lead's contacts and addresses.

## Relevant Technical Choices

Generalised APIs across Lead and Opportunity

## Testing Instructions

- [ ] Create opportunity from lead, prospect , customer
- [ ] Opportunity should only show it's or linked lead's contacts and Address not of any other

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2218