### PR TITLE
Hide call logs, email templates and todo pages

### DIFF
--- a/frontend/src/components/Layouts/AppSidebar.vue
+++ b/frontend/src/components/Layouts/AppSidebar.vue
@@ -140,21 +140,21 @@ const links = [
     icon: CustomersIcon,
     to: 'Customers',
   },
-  {
-    label: 'ToDos',
-    icon: ToDoIcon,
-    to: 'ToDos',
-  },
-  {
-    label: 'Call Logs',
-    icon: PhoneIcon,
-    to: 'Call Logs',
-  },
-  {
-    label: 'Email Templates',
-    icon: Email2Icon,
-    to: 'Email Templates',
-  },
+  // {
+  //   label: 'ToDos',
+  //   icon: ToDoIcon,
+  //   to: 'ToDos',
+  // },
+  // {
+  //   label: 'Call Logs',
+  //   icon: PhoneIcon,
+  //   to: 'Call Logs',
+  // },
+  // {
+  //   label: 'Email Templates',
+  //   icon: Email2Icon,
+  //   to: 'Email Templates',
+  // },
 ]
 
 const allViews = computed(() => {


### PR DESCRIPTION
## Description

Currently sidebar shows many pages like call logs, email templates and todo which are not needed on a daily basis.
Pages are not removed as they will be modifiable later.

This is a temporary hide.

## Relevant Technical Choices

Commented out pages

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/5e5f7ed1-ae06-4642-bf99-5d93f8e416f3)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Partially addresses: https://github.com/rtCamp/erp-rtcamp/issues/2208
