### PR TITLE
fix notification text for opportunity

### DIFF
--- a/next_crm/api/comment.py
+++ b/next_crm/api/comment.py
@@ -22,11 +22,7 @@ def notify_mentions(doc):
         doctype = doc.reference_doctype
         if doctype.startswith("CRM "):
             doctype = doctype[4:].lower()
-        name = (
-            reference_doc.title or reference_doc.name or None
-            if doctype == "Lead"
-            else reference_doc.party_name or None
-        )
+        name = reference_doc.title or reference_doc.name or None
         notification_text = f"""
             <div class="mb-2 leading-5 text-ink-gray-5">
                 <span class="font-medium text-ink-gray-9">{ owner }</span>


### PR DESCRIPTION
## Description

Notification text in Opportunity showed party name, it should instead show opportunity name or title.

## Testing Instructions

- [ ] Tag someone in a opportunity
- [ ] Check that the notification should show opportunity name or title

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)