### PR TITLE
Monkey patch set_participants_email method to prevent adding client email

### DIFF
--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -262,7 +262,6 @@ async function updateEvent() {
         {
           reference_doctype: props.doctype,
           reference_docname: props.doc || null,
-          email: getUser().email,
         },
         ...event_participants.value.map((email) => ({
           reference_doctype: 'User',
@@ -296,7 +295,7 @@ function render() {
         .filter((participant) => participant.reference_doctype === 'User' && participant.reference_docname === 'Guest')
         .map((participant) => participant.email)
     } else {
-      event_participants.value = []
+      event_participants.value = [getUser().email]
     }
   })
 }

--- a/next_crm/__init__.py
+++ b/next_crm/__init__.py
@@ -3,11 +3,13 @@ __title__ = "Next CRM"
 
 import erpnext.crm.utils as erp_utils
 import frappe
+from frappe.desk.doctype.event import event as frappe_event
 
 
 def monkey_patch():
     erp_utils.link_open_tasks = link_open_tasks
     erp_utils.link_open_events = link_open_events
+    frappe_event.Event.set_participants_email = lambda self: None
 
 
 def link_open_tasks(ref_doctype, ref_docname, doc):


### PR DESCRIPTION
## Description

- This PR overrides the default behaviour of frappe that adds participant email to event participant if it is not set. 
- Ref: https://github.com/rtCamp/erp-rtcamp/issues/2206

## Relevant Technical Choices

- Did a monkey patch because Overriding class would have added dependency on other apps like `frappe_appointment` or `careers`, and since next-crm is a public app, it would not be feasible.

## Testing Instructions

- [ ] Ensure email of clients is not added even if the opportunity is created from prospect.
- [ ] Ensure other event related things, like frappe_appointment works fine.

## Additional Information:

- Need to ensure that if the function `set_participants_email` is later overridden in a Class Override, the overridden function should not add participants email. 

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #