### PR TITLE
Workflows: Build Test: Fix public/private repo dependency check

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -39,7 +39,7 @@ jobs:
           DEPS=$(grep -E "required_apps\s*=\s*\[" app_repo/*/hooks.py | sed 's/.*\[\(.*\)\]/\1/g' | tr -d '"' | tr -d "'" | tr ',' '\n' | awk '{$1=$1};1')
           rm -rf app_repo
           for dep in $DEPS; do
-            su frappe bash-c "bench get-app $dep"
+            su frappe bash -c "bench get-app $dep"
           done
 
       - name: Get APP and Build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,10 +47,10 @@ jobs:
           cd /home/frappe/frappe-bench
           if [ "${{ github.event.pull_request.head.repo.private }}" = "false" ]; then
             # Public repo
-            su frappe bash -c "bench get-app https://github.com/${{ github.repository }} --branch ${{ github.head_ref || github.ref_name }}"
+            su frappe bash -c "bench get-app https://github.com/${{ github.event.pull_request.head.repo.full_name }} --branch ${{ github.event.pull_request.head.ref }}"
           else
             # Private repo
-            su frappe bash -c "bench get-app https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.repository }} --branch ${{ github.head_ref || github.ref_name }}"
+            su frappe bash -c "bench get-app https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.event.pull_request.head.repo.full_name }} --branch ${{ github.event.pull_request.head.ref }}"
           fi
 
       - name: Cleanup

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -45,7 +45,13 @@ jobs:
       - name: Get APP and Build
         run: |
           cd /home/frappe/frappe-bench
-          su frappe bash -c "bench get-app https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.repository }} --branch ${{ github.head_ref || github.ref_name }}"
+          if [ "${{ github.event.pull_request.head.repo.private }}" = "false" ]; then
+            # Public repo
+            su frappe bash -c "bench get-app https://github.com/${{ github.repository }} --branch ${{ github.head_ref || github.ref_name }}"
+          else
+            # Private repo
+            su frappe bash -c "bench get-app https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.repository }} --branch ${{ github.head_ref || github.ref_name }}"
+          fi
 
       - name: Cleanup
         if: ${{ always() }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           cd /home/frappe/frappe-bench
           # Use public URL for public repos, authenticated URL for private repos
-          if [[ "${{ github.event.pull_request.head.repo.private }}" == "false" ]]; then
+          if [ "${{ github.event.pull_request.head.repo.private }}" = "false" ]; then
             # This is a public repository (could be a fork or not)
             git clone https://github.com/${{ github.event.pull_request.head.repo.full_name }} -b ${{ github.event.pull_request.head.ref }} --depth=1 app_repo
           else
@@ -39,7 +39,7 @@ jobs:
           DEPS=$(grep -E "required_apps\s*=\s*\[" app_repo/*/hooks.py | sed 's/.*\[\(.*\)\]/\1/g' | tr -d '"' | tr -d "'" | tr ',' '\n' | awk '{$1=$1};1')
           rm -rf app_repo
           for dep in $DEPS; do
-            su frappe bash -c "bench get-app $dep"
+            su frappe bash-c "bench get-app $dep"
           done
 
       - name: Get APP and Build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -28,7 +28,14 @@ jobs:
       - name: Get Dependent Apps
         run: |
           cd /home/frappe/frappe-bench
-          git clone https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.repository }} -b ${{ github.head_ref || github.ref_name }} --depth=1 app_repo
+          # Use public URL for public repos, authenticated URL for private repos
+          if [[ "${{ github.event.pull_request.head.repo.private }}" == "false" ]]; then
+            # This is a public repository (could be a fork or not)
+            git clone https://github.com/${{ github.event.pull_request.head.repo.full_name }} -b ${{ github.event.pull_request.head.ref }} --depth=1 app_repo
+          else
+            # Private repository, use authentication
+            git clone https://rtbot:${{ secrets.RTBOT_TOKEN }}@github.com/${{ github.event.pull_request.head.repo.full_name }} -b ${{ github.event.pull_request.head.ref }} --depth=1 app_repo
+          fi
           DEPS=$(grep -E "required_apps\s*=\s*\[" app_repo/*/hooks.py | sed 's/.*\[\(.*\)\]/\1/g' | tr -d '"' | tr -d "'" | tr ',' '\n' | awk '{$1=$1};1')
           rm -rf app_repo
           for dep in $DEPS; do


### PR DESCRIPTION
This pull request updates the logic for cloning dependent apps in the GitHub Actions workflow to handle both public and private repositories. The most important change ensures that the correct URL is used based on the repository's privacy settings.

### Workflow improvements:

* [`.github/workflows/build-test.yml`](diffhunk://#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32L31-R38): Updated the `Get Dependent Apps` step to use a public URL for public repositories and an authenticated URL for private repositories. This change ensures compatibility with both public and private forks of the repository.