### PR TITLE
Add system wide default view settings

### DIFF
--- a/frontend/src/utils/view.js
+++ b/frontend/src/utils/view.js
@@ -37,16 +37,15 @@ export function getView(view, type, doctype) {
 
 export async function setDefaultViewCache() {
    const defaultOpenViews = await call('next_crm.api.views.get_default_open_view')
-   localStorage.setItem("defaultOpenViews", JSON.stringify(defaultOpenViews));
+   sessionStorage.setItem("defaultOpenViews", JSON.stringify(defaultOpenViews));
    return defaultOpenViews
 }
 
 export async function getDefaultView(doc, route) {
-  let defaultOpenViews = JSON.parse(localStorage.getItem("defaultOpenViews"));
+  let defaultOpenViews = JSON.parse(sessionStorage.getItem("defaultOpenViews"));
   if (!defaultOpenViews) {
     defaultOpenViews = await setDefaultViewCache()
   }
-
   if ((!route.params.viewType || route.params.viewType == "") && defaultOpenViews[doc]) {
     route.params.viewType = defaultOpenViews[doc]
   }

--- a/next_crm/api/views.py
+++ b/next_crm/api/views.py
@@ -30,23 +30,18 @@ def get_default_open_view():
         },
     )
 
-    fallback_views = frappe.get_all(
-        "CRM View Settings",
-        fields=["dt", "type"],
-        filters={
-            "user": "",
-            "default_open_view": 1,
-            "is_default": 1,
-            "dt": ["is", "set"],
-        },
-    )
-
     default_view_object = {}
     for view in views:
         default_view_object[view.dt] = view.type
 
-    for view in fallback_views:
-        if not default_view_object[view.dt]:
-            default_view_object[view.dt] = view.type
+    if not default_view_object.get("Lead"):
+        default_view_object["Lead"] = frappe.db.get_single_value(
+            "NCRM Settings", "lead_view"
+        )
+
+    if not default_view_object.get("Opportunity"):
+        default_view_object["Opportunity"] = frappe.db.get_single_value(
+            "NCRM Settings", "opportunity_view"
+        )
 
     return default_view_object

--- a/next_crm/ncrm/doctype/ncrm_settings/ncrm_settings.json
+++ b/next_crm/ncrm/doctype/ncrm_settings/ncrm_settings.json
@@ -1,40 +1,63 @@
 {
- "actions": [],
- "allow_rename": 1,
- "creation": "2024-09-29 13:48:02.715924",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "restore_defaults"
- ],
- "fields": [
-  {
-   "fieldname": "restore_defaults",
-   "fieldtype": "Button",
-   "label": "Restore Defaults"
-  }
- ],
- "index_web_pages_for_search": 1,
- "issingle": 1,
- "links": [],
- "modified": "2024-09-29 13:49:07.835379",
- "modified_by": "Administrator",
- "module": "NCRM",
- "name": "NCRM Settings",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "sort_field": "creation",
- "sort_order": "DESC",
- "states": []
+  "actions": [],
+  "allow_rename": 1,
+  "creation": "2024-09-29 13:48:02.715924",
+  "doctype": "DocType",
+  "engine": "InnoDB",
+  "field_order": [
+    "restore_defaults",
+    "default_view_section",
+    "lead_view",
+    "opportunity_view"
+  ],
+  "fields": [
+    {
+      "fieldname": "restore_defaults",
+      "fieldtype": "Button",
+      "label": "Restore Defaults"
+    },
+    {
+      "fieldname": "default_view_section",
+      "fieldtype": "Section Break",
+      "label": "Default View"
+    },
+    {
+      "default": "kanban",
+      "fieldname": "lead_view",
+      "fieldtype": "Select",
+      "label": "Lead View",
+      "options": "list\nkanban"
+    },
+    {
+      "default": "kanban",
+      "fieldname": "opportunity_view",
+      "fieldtype": "Select",
+      "label": "Opportunity View",
+      "options": "list\nkanban"
+    }
+  ],
+  "index_web_pages_for_search": 1,
+  "issingle": 1,
+  "links": [],
+  "modified": "2025-05-02 14:10:07.422356",
+  "modified_by": "Administrator",
+  "module": "NCRM",
+  "name": "NCRM Settings",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "print": 1,
+      "read": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+    }
+  ],
+  "row_format": "Dynamic",
+  "sort_field": "creation",
+  "sort_order": "DESC",
+  "states": []
 }


### PR DESCRIPTION
## Description

Currently default view is on a per user basis and saved in the local storage.
This makes it hard to refresh and doesn't support on the fly default changes through backend.
Also, it is harder to set a system wide view for a company which might prefer one view over the others.

This can be fixed with a system vide default view setting

## Relevant Technical Choices

1) Add a setting in NCRM settings to change the default view
2) Store default view in session instead of local storage
3) Use precedence -> `User default > System default > List`
4) System default view is only supported in Lead and Opportunity

## Testing Instructions

1. Set a default system view
2. Check all users should have that as the default view now
3. Now try setting a default view from the user
4. This should now override the system default view

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/411e05af-fac7-4495-8c1f-bbb824a1e42a)

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
