### PR TITLE
Append percentage sign to probability in Kanban

### DIFF
--- a/frontend/src/pages/Opportunities.vue
+++ b/frontend/src/pages/Opportunities.vue
@@ -134,8 +134,11 @@
             size="xs"
           />
         </div>
+        <div v-else-if="fieldName === 'probability'">
+          {{ getRow(itemName, fieldName).label }}%
+        </div>
         <div
-          v-if="
+          v-else-if="
             [
               'modified',
               'creation',


### PR DESCRIPTION
## Description

Probability doesn't appear as percentage in Kanban. This can be fixed by adding a if check like we have for other special format fields such as user, status, modified, etc...

## Testing Instructions

In Kanban, probability should display a percentage sign after it

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/f3113aaa-2bc7-4ef3-b3b7-c80de90dddf4)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2214