### PR TITLE
Fix lead to opportunity conversion and contact linking through new creation

### DIFF
--- a/frontend/src/components/Modals/LinkContactModal.vue
+++ b/frontend/src/components/Modals/LinkContactModal.vue
@@ -41,7 +41,13 @@
       </div>
     </template>
   </Dialog>
-  <ContactModal v-model="showNewContactModal" />
+  <ContactModal
+    v-model="showNewContactModal"
+    :options="{
+      redirect: false,
+      afterInsert: addNewContact,
+    }"
+  />
 </template>
 <script setup>
 import ContactModal from '@/components/Modals/ContactModal.vue'
@@ -90,6 +96,11 @@ async function addContact() {
       iconClasses: 'text-ink-red-4',
     })
   }
+}
+
+function addNewContact(doc) {
+  existingContact.value = doc.name
+  addContact()
 }
 
 function showContactModal() {

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -1023,7 +1023,7 @@ const existingProspect = ref('')
 
 async function convertToOpportunity() {
 
-  if (!lead.data.company_name) {
+  if (!existingProspectChecked.value && !lead.data.company_name) {
     createToast({
       title: __('Error'),
       text: __('Please enter organisation name to create new Prospect'),

--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -35,10 +35,10 @@
             label: __('Opportunity'),
             onClick: createOpportunity
           },
-          {
-            label: __('Customer'),
-            onClick: createCustomer
-          },
+          // {
+          //   label: __('Customer'),
+          //   onClick: createCustomer
+          // },
         ]"
         @click.stop
       >
@@ -638,6 +638,7 @@ async function createCustomer() {
             close()
             router.push({ name: 'Customer', params: { customerId: customer } })
           } catch (error) {
+            console.log(error)
             createToast({
               title: __('Error'),
               text: error,

--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -638,7 +638,6 @@ async function createCustomer() {
             close()
             router.push({ name: 'Customer', params: { customerId: customer } })
           } catch (error) {
-            console.log(error)
             createToast({
               title: __('Error'),
               text: error,


### PR DESCRIPTION
## Description

1. Lead to opportunity conversion should not throw errors about organisation name not set if existing prospect is checked
2. Adding contact to prospect or customer through new creation should work like address where it link automatically and doesn't redirect
3. Customer creation should be hidden from the prospect page due to default currency and abbreviation issues


## Testing Instructions

1. Linking new contact should automatically work without redirect
2. Lead to opportunity conversion shouldn't throw error if existing prospect is checked

## Additional Information:

**Note**: Layout of prospect should be updated to hide company name.


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
