### PR TITLE
add individual tab count in opportunity and lead

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -380,6 +380,12 @@ const all_activities = createResource({
   cache: ['activity', doc.value.data.name],
   auto: true,
   transform: ([versions, calls, notes, todos, events, attachments]) => {
+    props.tabs[1].count.value = versions.filter((activity) => activity.activity_type === 'communication').length
+    props.tabs[2].count.value = versions.filter((activity) => activity.activity_type === 'comment').length
+    props.tabs[3].count.value = todos.length
+    props.tabs[4].count.value = events.length
+    props.tabs[5].count.value = notes.length
+    props.tabs[6].count.value = attachments.length
     return { versions, calls, notes, todos, events, attachments }
   },
 })

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -41,6 +41,23 @@
   </LayoutHeader>
   <div v-if="lead?.data" class="flex h-full overflow-hidden">
     <Tabs as="div" v-model="tabIndex" :tabs="tabs">
+      <template #tab-item="{ tab, selected }">
+        <button
+          class="group flex items-center gap-2 border-b border-transparent py-2.5 text-base text-ink-gray-5 duration-300 ease-in-out hover:border-gray-400 hover:text-ink-gray-9"
+          :class="{ 'text-ink-gray-9': selected }"
+        >
+          <component v-if="tab.icon" :is="tab.icon" class="h-5" />
+          {{ __(tab.label) }}
+          <Badge
+            v-if="tab.label != 'Activity'"
+            variant="subtle"
+            theme="gray"
+            size="sm"
+          >
+            {{ tab.count || 0 }}
+          </Badge>
+        </button>
+      </template>
       <template #tab-panel>
         <Activities
           ref="activities"
@@ -924,48 +941,57 @@ const tabs = computed(() => {
       name: 'Activity',
       label: __('Activity'),
       icon: ActivityIcon,
+      count: ref(0)
     },
     {
       name: 'Emails',
       label: __('Emails'),
       icon: EmailIcon,
+      count: ref(0)
     },
     {
       name: 'Comments',
       label: __('Comments'),
       icon: CommentIcon,
+      count: ref(0)
     },
     {
       name: 'Calls',
       label: __('Calls'),
       icon: PhoneIcon,
       condition: () => callEnabled.value,
+      count: ref(0)
     },
     {
       name: 'ToDos',
       label: __('ToDos'),
       icon: ToDoIcon,
+      count: ref(0)
     },
     {
       name: 'Events',
       label: __('Events'),
       icon: EventIcon,
+      count: ref(0)
     },
     {
       name: 'Notes',
       label: __('Notes'),
       icon: NoteIcon,
+      count: ref(0)
     },
     {
       name: 'Attachments',
       label: __('Attachments'),
       icon: AttachmentIcon,
+      count: ref(0)
     },
     {
       name: 'WhatsApp',
       label: __('WhatsApp'),
       icon: WhatsAppIcon,
       condition: () => whatsappEnabled.value,
+      count: ref(0)
     },
   ]
   return tabOptions.filter((tab) => (tab.condition ? tab.condition() : true))

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -50,7 +50,7 @@
           {{ __(tab.label) }}
           <Badge
             v-if="tab.label != 'Activity'"
-            variant="subtle"
+            variant="solid"
             theme="gray"
             size="sm"
           >

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -36,6 +36,23 @@
   </LayoutHeader>
   <div v-if="opportunity.data" class="flex h-full overflow-hidden">
     <Tabs as="div" v-model="tabIndex" :tabs="tabs">
+      <template #tab-item="{ tab, selected }">
+        <button
+          class="group flex items-center gap-2 border-b border-transparent py-2.5 text-base text-ink-gray-5 duration-300 ease-in-out hover:border-gray-400 hover:text-ink-gray-9"
+          :class="{ 'text-ink-gray-9': selected }"
+        >
+          <component v-if="tab.icon" :is="tab.icon" class="h-5" />
+          {{ __(tab.label) }}
+          <Badge
+            v-if="tab.label != 'Activity'"
+            variant="subtle"
+            theme="gray"
+            size="sm"
+          >
+            {{ tab.count || 0 }}
+          </Badge>
+        </button>
+      </template>
       <template #tab-panel>
         <Activities
           ref="activities"
@@ -688,43 +705,51 @@ const tabs = computed(() => {
       name: 'Emails',
       label: __('Emails'),
       icon: EmailIcon,
+      count: ref(0)
     },
     {
       name: 'Comments',
       label: __('Comments'),
       icon: CommentIcon,
+      count: ref(0)
     },
     {
       name: 'Calls',
       label: __('Calls'),
       icon: PhoneIcon,
       condition: () => callEnabled.value,
+      count: ref(0)
     },
     {
       name: 'ToDos',
       label: __('ToDos'),
       icon: ToDoIcon,
+      count: ref(0)
     },
     {
       name: 'Events',
       label: __('Events'),
       icon: EventIcon,
+      count: ref(0)
     },
     {
       name: 'Notes',
       label: __('Notes'),
       icon: NoteIcon,
+      count: ref(0)
     },
     {
       name: 'Attachments',
       label: __('Attachments'),
       icon: AttachmentIcon,
+      count: ref(0)
     },
     {
       name: 'WhatsApp',
       label: __('WhatsApp'),
       icon: WhatsAppIcon,
       condition: () => whatsappEnabled.value,
+      count: ref(0)
     },
   ]
   return tabOptions.filter((tab) => (tab.condition ? tab.condition() : true))

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -45,7 +45,7 @@
           {{ __(tab.label) }}
           <Badge
             v-if="tab.label != 'Activity'"
-            variant="subtle"
+            variant="solid"
             theme="gray"
             size="sm"
           >


### PR DESCRIPTION
## Description

In Kanban view the item count is visible.
It sums up the number of notes, emails, todos, etc...
This can be useful in detailed view of opportunity and lead.
This PR adds item counts as badge along with the tabs.

## Relevant Technical Choices

The code is similar to the one used for listview count in other pages.
A new parameter `count` is added to store the count as a reactive variable.
This approach prevents doing extra api call or modifying current api.

## Testing Instructions

1. Count should be visible in topbar
2. Count should update on creating new comment, todo, etc...


## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/8ad20374-1082-4382-8ac3-c5799c337bc9)
![image](https://github.com/user-attachments/assets/ddf2fa3e-2ed2-49ff-a9fe-d253f02c231e)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes https://github.com/rtCamp/erp-rtcamp/issues/2208