### PR TITLE
Show and sort notes based on added_on

### DIFF
--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -8,9 +8,9 @@
         </span>
       </div>
       <div class="flex items-center gap-2 ml-auto whitespace-nowrap">
-        <Tooltip :text="dateFormat(note.modified, dateTooltipFormat)">
+        <Tooltip :text="dateFormat(note.added_on, dateTooltipFormat)">
           <div class="truncate text-sm text-ink-gray-7">
-            {{ __(timeAgo(note.modified)) }}
+            {{ __(timeAgo(note.added_on)) }}
           </div>
         </Tooltip>
         <Dropdown

--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -203,6 +203,7 @@ def get_opportunity_activities(name):
 
     activities.sort(key=lambda x: x["creation"], reverse=True)
     activities = handle_multiple_versions(activities)
+    notes.sort(key=lambda x: x["added_on"], reverse=True)
 
     return activities, calls, notes, todos, events, attachments
 
@@ -376,6 +377,7 @@ def get_lead_activities(name, get_events=True):
 
     activities.sort(key=lambda x: x["creation"], reverse=True)
     activities = handle_multiple_versions(activities)
+    notes.sort(key=lambda x: x["added_on"], reverse=True)
 
     return activities, calls, notes, todos, events, attachments
 
@@ -468,7 +470,7 @@ def get_linked_notes(name):
     notes = frappe.db.get_all(
         "CRM Note",
         filters={"parent": name},
-        fields=["name", "custom_title", "note", "owner", "modified"],
+        fields=["name", "custom_title", "note", "owner", "added_on"],
     )
     return notes or []
 


### PR DESCRIPTION
## Description

The notes currently show `modified` date.
This behaviour is not optimal due to the fact that child table modified gets updated on other rows update as well.
CRM Note doc has a `Added On` field which could instead be shown. This field will show creation data, which is also ERP backend default behaviour

## Relevant Technical Choices

Changed notes sorting order to sort based on `Added On`
Changed note area ui to show added on date

## Testing Instructions

- [ ] Create a new note
- [ ] Check that should not modify any other note's timestamp on UI side
- [ ] Now modify the note, it should also not cause modifications.

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2220