### PR TITLE
Add address and contacts to sidepanel install hook

### DIFF
--- a/next_crm/install.py
+++ b/next_crm/install.py
@@ -158,11 +158,11 @@ def add_default_fields_layout(force=False):
     sidebar_fields_layouts = {
         "Lead-Side Panel": {
             "doctype": "Lead",
-            "layout": '[{"label": "Details", "name": "details", "opened": true, "fields": ["customer", "website", "territory", "industry", "job_title", "source", "lead_owner"]}, {"label": "Person", "name": "person_tab", "opened": true, "fields": ["salutation", "first_name", "last_name", "email_id", "mobile_no"]}]',
+            "layout": '[{"label":"Addresses","name":"addresses_section","opened":true,"editable":false,"addresses":[]},{"label":"Contacts","name":"contacts_section","opened":true,"editable":false,"contacts":[]},{"label": "Details", "name": "details", "opened": true, "fields": ["customer", "website", "territory", "industry", "job_title", "source", "lead_owner"]}, {"label": "Person", "name": "person_tab", "opened": true, "fields": ["salutation", "first_name", "last_name", "email_id", "mobile_no"]}]',
         },
         "Opportunity-Side Panel": {
             "doctype": "Opportunity",
-            "layout": '[{"label":"Contacts","name":"contacts_section","opened":true,"editable":false,"contacts":[]},{"label":"Customer Details","name":"customer_tab","opened":true,"fields":["customer","website","territory","opportunity_amount","transaction_date","probability","opportunity_owner"]}]',
+            "layout": '[{"label":"Addresses","name":"addresses_section","opened":true,"editable":false,"addresses":[]},{"label":"Contacts","name":"contacts_section","opened":true,"editable":false,"contacts":[]},{"label":"Customer Details","name":"customer_tab","opened":true,"fields":["customer","website","territory","opportunity_amount","transaction_date","probability","opportunity_owner"]}]',
         },
         "Prospect-Side Panel": {
             "doctype": "Prospect",


### PR DESCRIPTION
## Description

Currently the address and contacts sections in sidepanel of lead and opportunity are manipulated through patch. This was done to modify any existing installs, but is not optimal for new installs.
The sections should also be added to install hooks as patches first check if the section is not present and only then add, thus it won't cause problems.

## Relevant Technical Choices

Added layout changes to install hooks

## Testing Instructions

- [ ] Do a fresh install of crm or a reinstall
- [ ] The opportunity and lead page should show address and contacts sections in side panel

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
