### PR TITLE
Remove notes duplication on lead to opportunity

### DIFF
--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -41,7 +41,6 @@ def get_opportunity_activities(name):
 
     activities = []
     calls = []
-    notes = []
     todos = []
     events = []
     attachments = []
@@ -49,7 +48,7 @@ def get_opportunity_activities(name):
 
     if opportunity_from == "Lead":
         lead = doc[3]
-        activities, calls, notes, todos, events, attachments = get_lead_activities(
+        activities, calls, _notes, todos, events, attachments = get_lead_activities(
             lead, False
         )
         creation_text = "converted the lead to this opportunity"
@@ -196,7 +195,7 @@ def get_opportunity_activities(name):
         activities.append(activity)
 
     calls = calls + get_linked_calls(name)
-    notes = notes + get_linked_notes(name)
+    notes = get_linked_notes(name)
     todos = todos + get_linked_todos(name)
     events = events + get_linked_events(name)
     attachments = attachments + get_attachments("Opportunity", name)


### PR DESCRIPTION
## Description

NextCRM frontend shows notes from both opportunity and linked lead in an opportunity. This is no longer needed from frontend manipulation as notes are instead added to opportunity as well, causing the API to show duplicate notes on frontend.

Notes from leads are carry forwarded so functionality will remain same, only duplication will be removed.

## Relevant Technical Choices

Concatenation of notes is removed

## Testing Instructions

- [ ] Create a lead
- [ ] Create multiple notes in lead
- [ ] Convert lead to opportunity
- [ ] The opportunity should show all notes of lead and opportunity without any duplication

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
