### PR TITLE
Add Priority status in opportunity list-view and kanban-view

### DIFF
--- a/frontend/src/components/ListViews/OpportunitiesListView.vue
+++ b/frontend/src/components/ListViews/OpportunitiesListView.vue
@@ -124,6 +124,15 @@
           <div v-else-if="column.type === 'Check'">
             <FormControl type="checkbox" :modelValue="item" :disabled="true" class="text-ink-gray-9" />
           </div>
+          <div v-else-if="column.key === 'custom_priority'" class="truncate text-base">
+            <Badge
+              v-if="item"
+              :variant="'subtle'"
+              :theme="item === 'High' ? 'red' : item === 'Medium' ? 'orange' : 'gray'"
+              size="md"
+              :label="item"
+            />
+          </div>
           <div
             v-else
             class="truncate text-base"

--- a/frontend/src/pages/Opportunities.vue
+++ b/frontend/src/pages/Opportunities.vue
@@ -43,68 +43,73 @@
     @update="(data) => viewControls.updateKanbanSettings(data)"
     @loadMore="(columnName) => viewControls.loadMoreKanban(columnName)"
   >
-    <template #title="{ titleField, itemName }">
-      <div class="flex gap-2 items-center">
-        <div v-if="titleField === 'status'">
-          <IndicatorIcon :class="getRow(itemName, titleField).color" />
+    <template #title="{ fields, titleField, itemName }">
+      <div class="flex gap-2 items-center justify-between">
+        <div class="flex gap-2 items-center">
+          <div v-if="titleField === 'status'">
+            <IndicatorIcon :class="getRow(itemName, titleField).color" />
+          </div>
+          <div
+            v-else-if="
+              titleField === 'customer' && getRow(itemName, titleField).label
+            "
+          >
+            <Avatar
+              class="flex items-center"
+              :image="getRow(itemName, titleField).logo"
+              :label="getRow(itemName, titleField).label"
+              size="sm"
+            />
+          </div>
+          <div
+            v-else-if="
+              titleField === 'opportunity_owner' &&
+              getRow(itemName, titleField).full_name
+            "
+          >
+            <Avatar
+              class="flex items-center"
+              :image="getRow(itemName, titleField).user_image"
+              :label="getRow(itemName, titleField).full_name"
+              size="sm"
+            />
+          </div>
+          <div
+            v-if="
+              [
+                'modified',
+                'creation',
+                'first_response_time',
+                'first_responded_on',
+                'response_by',
+              ].includes(titleField)
+            "
+            class="truncate text-base"
+          >
+            <Tooltip :text="getRow(itemName, titleField).label">
+              <div>{{ getRow(itemName, titleField).timeAgo }}</div>
+            </Tooltip>
+          </div>
+          <div v-else-if="titleField === 'sla_status'" class="truncate text-base">
+            <Badge
+              v-if="getRow(itemName, titleField).value"
+              :variant="'subtle'"
+              :theme="getRow(itemName, titleField).color"
+              size="md"
+              :label="getRow(itemName, titleField).value"
+            />
+          </div>
+          <div
+            v-else-if="getRow(itemName, titleField).label"
+            class="text-base"
+          >
+            {{ getRow(itemName, titleField).label }}
+          </div>
+          <div class="text-ink-gray-4" v-else>{{ __('No Title') }}</div>
         </div>
-        <div
-          v-else-if="
-            titleField === 'customer' && getRow(itemName, titleField).label
-          "
-        >
-          <Avatar
-            class="flex items-center"
-            :image="getRow(itemName, titleField).logo"
-            :label="getRow(itemName, titleField).label"
-            size="sm"
-          />
-        </div>
-        <div
-          v-else-if="
-            titleField === 'opportunity_owner' &&
-            getRow(itemName, titleField).full_name
-          "
-        >
-          <Avatar
-            class="flex items-center"
-            :image="getRow(itemName, titleField).user_image"
-            :label="getRow(itemName, titleField).full_name"
-            size="sm"
-          />
-        </div>
-        <div
-          v-if="
-            [
-              'modified',
-              'creation',
-              'first_response_time',
-              'first_responded_on',
-              'response_by',
-            ].includes(titleField)
-          "
-          class="truncate text-base"
-        >
-          <Tooltip :text="getRow(itemName, titleField).label">
-            <div>{{ getRow(itemName, titleField).timeAgo }}</div>
-          </Tooltip>
-        </div>
-        <div v-else-if="titleField === 'sla_status'" class="truncate text-base">
-          <Badge
-            v-if="getRow(itemName, titleField).value"
-            :variant="'subtle'"
-            :theme="getRow(itemName, titleField).color"
-            size="md"
-            :label="getRow(itemName, titleField).value"
-          />
-        </div>
-        <div
-          v-else-if="getRow(itemName, titleField).label"
-          class="text-base"
-        >
-          {{ getRow(itemName, titleField).label }}
-        </div>
-        <div class="text-ink-gray-4" v-else>{{ __('No Title') }}</div>
+        <Badge v-if='fields["custom_priority"]' :variant="'subtle'" :theme="fields['custom_priority'] === 'High' ? 'red' : fields['custom_priority'] === 'Medium' ? 'orange' : 'gray'" class="text-base">
+          {{ fields["custom_priority"] }}
+        </Badge>
       </div>
     </template>
 

--- a/frontend/src/pages/Opportunities.vue
+++ b/frontend/src/pages/Opportunities.vue
@@ -107,9 +107,7 @@
           </div>
           <div class="text-ink-gray-4" v-else>{{ __('No Title') }}</div>
         </div>
-        <Badge v-if='fields["custom_priority"]' :variant="'subtle'" :theme="fields['custom_priority'] === 'High' ? 'red' : fields['custom_priority'] === 'Medium' ? 'orange' : 'gray'" class="text-base">
-          {{ fields["custom_priority"] }}
-        </Badge>
+        <Badge v-if='fields["custom_priority"]' :variant="'subtle'" :theme="fields['custom_priority'] === 'High' ? 'red' : fields['custom_priority'] === 'Medium' ? 'orange' : 'gray'" class="text-base" :label="fields['custom_priority']"/>
       </div>
     </template>
 


### PR DESCRIPTION
## Description

This PR adds Priority status in Opportunity list view and kanban view.

## Relevant Technical Choices

- Add Priority status

## Testing Instructions

- Visit Opportunity ListView
- Add Priority status field from column selector
- Open Opportunity Kanban view
- There should a priority status shown in title of the kanban card

## Additional Information:

> [!NOTE]
> This PR  is important to show priority field  on `next-crm` https://github.com/rtCamp/erp-rtcamp/pull/2266

## Screenshot/Screencast

Kanban view:

![image](https://github.com/user-attachments/assets/efcb9462-4e7e-4796-a7bc-c25465ae6e39)

List View
![image](https://github.com/user-attachments/assets/1b2a2a9e-f110-46e8-bd58-4287f69b6500)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Addresses: https://github.com/rtCamp/erp-rtcamp/issues/2208#issuecomment-2846488392