### PR TITLE
Migrate lead contacts, addresses to opportunity on conversion

### DIFF
--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -854,9 +854,10 @@ async function addContact(contact) {
 }
 
 async function addAddress(address) {
-  let d = await call('next_crm.api.opportunity.add_address', {
-    opportunity: props.opportunityId,
+  let d = await call('next_crm.api.address.link_address_to_doc', {
     address,
+    doctype: "Opportunity",
+    docname: props.opportunityId,
   })
   if (d) {
     opportunityAddresses.reload()

--- a/next_crm/api/address.py
+++ b/next_crm/api/address.py
@@ -98,7 +98,7 @@ def remove_address(link_doctype, link_name, address):
 
 
 def migrate_lead_addresses_to_opportunity(lead_name, opportunity_name):
-    addresses = frappe.get_list(
+    addresses = frappe.get_all(
         "Address",
         filters=[
             ["Dynamic Link", "link_doctype", "=", "Lead"],

--- a/next_crm/api/opportunity.py
+++ b/next_crm/api/opportunity.py
@@ -29,32 +29,6 @@ def get_opportunity(name):
 
 
 @frappe.whitelist()
-def add_address(opportunity, address):
-    if not frappe.has_permission("Opportunity", "write", opportunity):
-        frappe.throw(
-            _("Not allowed to add address to Opportunity"), frappe.PermissionError
-        )
-
-    opportunity_doc = frappe.get_cached_doc("Opportunity", opportunity)
-    address_doc = frappe.get_doc("Address", address)
-
-    if opportunity_doc.opportunity_from:
-        address_doc.append(
-            "links",
-            {
-                "link_doctype": opportunity_doc.opportunity_from,
-                "link_name": opportunity_doc.party_name,
-            },
-        )
-
-    address_doc.append(
-        "links", {"link_doctype": "Opportunity", "link_name": opportunity}
-    )
-    address_doc.save()
-    return True
-
-
-@frappe.whitelist()
 def declare_enquiry_lost_api(
     name, lost_reasons_list, competitors, detailed_reason=None
 ):

--- a/next_crm/overrides/lead.py
+++ b/next_crm/overrides/lead.py
@@ -201,6 +201,7 @@ class Lead(Lead):
     def create_opportunity(self, contact, customer_or_prospect):
         from erpnext.crm.doctype.lead.lead import make_opportunity
 
+        from next_crm.api.address import migrate_lead_addresses_to_opportunity
         from next_crm.api.contact import (
             link_contact_to_doc,
             set_opportunity_primary_contact,
@@ -227,6 +228,7 @@ class Lead(Lead):
 
         opportunity.insert()
         link_contact_to_doc(contact, "Opportunity", opportunity.name)
+        migrate_lead_addresses_to_opportunity(self.name, opportunity.name)
         set_opportunity_primary_contact(opportunity.name)
         return opportunity.name
 

--- a/next_crm/overrides/lead.py
+++ b/next_crm/overrides/lead.py
@@ -204,6 +204,7 @@ class Lead(Lead):
         from next_crm.api.address import migrate_lead_addresses_to_opportunity
         from next_crm.api.contact import (
             link_contact_to_doc,
+            migrate_lead_contacts_to_opportunity,
             set_opportunity_primary_contact,
         )
 
@@ -229,6 +230,7 @@ class Lead(Lead):
         opportunity.insert()
         link_contact_to_doc(contact, "Opportunity", opportunity.name)
         migrate_lead_addresses_to_opportunity(self.name, opportunity.name)
+        migrate_lead_contacts_to_opportunity(self.name, opportunity.name)
         set_opportunity_primary_contact(opportunity.name)
         return opportunity.name
 


### PR DESCRIPTION
## Description

Currently any new address added to opportunity is also linked back to the linked lead.
Opportunity also visually shows addresses from linked lead for migration.
Both of these are better solved with migrating all addresses to also be linked with opportunity.
This reduces distinct API for address link logic and makes the feature more robust be eliminating backend and frontend discrepancy. 

The same is true for contacts as well. Hence the PR also updates contacts logic.

## Relevant Technical Choices

All addresses linked to lead will also get linked to opportunity

## Testing Instructions

- [ ] Create a lead
- [ ] link a address
- [ ] convert lead to opportunity
- [ ] Link another address to opportunity which is created from lead
- [ ] Attempt to delete both the addresses
- [ ] The addresses should be deleted from the opportunity

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes https://github.com/rtCamp/erp-rtcamp/issues/2256