### PR TITLE
Truncate title and update tooltip in opportunity

### DIFF
--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -82,8 +82,8 @@
             />
           </div>
         </Tooltip>
-        <div class="flex flex-col gap-2.5 truncat text-ink-gray-9">
-          <Tooltip :text="customer.data?.name || opportunity.data?.party_name || __('Set an customer')">
+        <div class="flex flex-col gap-2.5 truncate text-ink-gray-9">
+          <Tooltip :text="customer.data?.name || opportunity.data?.title || opportunity.data?.party_name || __('Set an customer')">
             <div class="truncate text-2xl font-medium" @click="showRenameModal = true">
               {{ customer.data?.name || opportunity.data?.title || opportunity.data?.party_name || __('Untitled') }}
             </div>


### PR DESCRIPTION
## Description

In opportunity the title area doesn't get truncated if too long and also the tooltip order doesn't match the title order.


## Testing Instructions

- [ ] Set a very long title for opportunity
- [ ] The title should not get truncated (only visible if customer not added)


## Screenshot/Screencast

![Screenshot From 2025-05-13 13-08-51](https://github.com/user-attachments/assets/a071bc40-e6a4-4379-ae43-1053e3f6cd04)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
