### PR TITLE
Throw event error if calendar not selected

### DIFF
--- a/frontend/src/components/Activities/AllModals.vue
+++ b/frontend/src/components/Activities/AllModals.vue
@@ -61,7 +61,7 @@ function showToDo(t) {
 }
 
 function showEvent(t) {
-  const user_google_calendar = getUser().google_calendar;
+  const user_google_calendar = getUser().google_calendar
   event.value = t || {
     subtitle: '',
     description: '',
@@ -69,7 +69,9 @@ function showEvent(t) {
     starts_on: '',
     ends_on: '',
     status: 'Open',
-    sync_with_google_calendar: (user_google_calendar ? 1 : 0),
+    event_type: 'Private',
+    event_category: 'Event',
+    sync_with_google_calendar: user_google_calendar ? 1 : 0,
     google_calendar: user_google_calendar,
   }
   showEventModal.value = true

--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -230,6 +230,14 @@ async function updateEvent() {
   }
   if (!_event.value.sync_with_google_calendar) {
     _event.value.google_calendar = null
+  } else if (!_event.value.google_calendar) {
+    createToast({
+      title: __('Error'),
+      text: __('Select Google Calendar to which event should be synced'),
+      icon: 'x',
+      iconClasses: 'text-ink-red-4',
+    })
+    return
   }
   _event.value.assigned_by = getUser().name
   if (_event.value.name) {


### PR DESCRIPTION
## Description

Currently the event modal silently throws error if sync is checked but no google calendar is selected.
Also, it doesn't automatically select the event category and event type.

## Relevant Technical Choices

Added a toast message if sync is enabled but no calendar selected

## Testing Instructions

- [ ] Open new event modal, it should automatically select event category and type
- [ ] Attempt to save a event without any calendar selected


## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/77cc0451-5929-4bf1-9c73-481357080109)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

See #121 