### PR TITLE
Update tab count on page route change

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -380,12 +380,6 @@ const all_activities = createResource({
   cache: ['activity', doc.value.data.name],
   auto: true,
   transform: ([versions, calls, notes, todos, events, attachments]) => {
-    props.tabs[1].count.value = versions.filter((activity) => activity.activity_type === 'communication').length
-    props.tabs[2].count.value = versions.filter((activity) => activity.activity_type === 'comment').length
-    props.tabs[3].count.value = todos.length
-    props.tabs[4].count.value = events.length
-    props.tabs[5].count.value = notes.length
-    props.tabs[6].count.value = attachments.length
     return { versions, calls, notes, todos, events, attachments }
   },
 })
@@ -594,6 +588,18 @@ watch([reload, reload_email], ([reload_value, reload_email_value]) => {
     reload_email.value = false
   }
 })
+
+watch(
+  () => all_activities.data,
+  (value) => {
+    props.tabs[1].count.value = value?.versions.filter((activity) => activity.activity_type === 'communication').length
+    props.tabs[2].count.value = value?.versions.filter((activity) => activity.activity_type === 'comment').length
+    props.tabs[3].count.value = value?.todos.length
+    props.tabs[4].count.value = value?.events.length
+    props.tabs[5].count.value = value?.notes.length
+    props.tabs[6].count.value = value?.attachments.length
+  },
+)
 
 defineExpose({ emailBox, all_activities })
 </script>


### PR DESCRIPTION
## Description

The recently added tab count fails when a user go backs and forth or opens a cached page.
This can be fixed by changing the place of tab count update to be instead a watch function instead.

## Relevant Technical Choices

Moved the tab count update logic to `watch` , this updates the tab count whenever activity count updates.

## Testing Instructions

- [ ] Go back and forth and reload a page, the tab count should always show correct value


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)