### PR TITLE
Add multi-value support in Link filter.

### DIFF
--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -5,12 +5,13 @@
     </label>
     <Autocomplete
       ref="autocomplete"
-      :options="options.data"
+      :options="options.data ?? []"
       v-model="value"
       :size="attrs.size || 'sm'"
       :variant="attrs.variant"
       :placeholder="attrs.placeholder"
       :filterable="false"
+      :multiple="props.multiple"
     >
       <template #target="{ open, togglePopover }">
         <slot name="target" v-bind="{ open, togglePopover }" />
@@ -54,7 +55,7 @@
 </template>
 
 <script setup>
-import Autocomplete from '@/components/frappe-ui/Autocomplete.vue'
+import { Autocomplete } from 'frappe-ui'
 import { watchDebounced } from '@vueuse/core'
 import { createResource } from 'frappe-ui'
 import { useAttrs, computed, ref } from 'vue'
@@ -69,13 +70,17 @@ const props = defineProps({
     default: () => [],
   },
   modelValue: {
-    type: String,
+    type: [String, Array],
     default: '',
   },
   hideMe: {
     type: Boolean,
     default: false,
   },
+  multiple:{
+    type: Boolean,
+    default: false,
+  }
 })
 
 const emit = defineEmits(['update:modelValue', 'change'])
@@ -87,7 +92,11 @@ const valuePropPassed = computed(() => 'value' in attrs)
 const value = computed({
   get: () => (valuePropPassed.value ? attrs.value : props.modelValue),
   set: (val) => {
-    return val?.value && emit(valuePropPassed.value ? 'change' : 'update:modelValue', val?.value)
+    if (props.multiple) {
+      emit(valuePropPassed.value ? 'change' : 'update:modelValue', val.map(v => v.value))
+    } else {
+      emit(valuePropPassed.value ? 'change' : 'update:modelValue', val?.value)
+    }
   },
 })
 

--- a/frontend/src/components/Filter.vue
+++ b/frontend/src/components/Filter.vue
@@ -381,7 +381,22 @@ function getValueControl(f) {
       type: 'select',
       options: timespanOptions,
     })
-  } else if (['like', 'not like', 'in', 'not in'].includes(operator)) {
+  } else if (['in', 'not in'].includes(operator)) {
+    if (typeSelect.includes(fieldtype)) {
+      const _options = getSelectOptions(options)
+      return h(FormControl, {
+        type: 'select',
+        options: _options.map((o) => ({
+          label: o,
+          value: o,
+        })),
+      })
+    } else if (fieldtype == 'Link') {
+      return h(Link, { class: 'border-none', doctype: options, value: f.value, multiple: true })
+    } else {
+      return h(FormControl, { type: 'text' })
+    }
+  } else if (['like', 'not like'].includes(operator)) {
     return h(FormControl, { type: 'text' })
   } else if (typeSelect.includes(fieldtype) || typeCheck.includes(fieldtype)) {
     const _options =


### PR DESCRIPTION
## Description

This PR updates link component to support multi-value for `In` and `Not In` filters for better UX.

## Relevant Technical Choices

- Update Link component to use `frappe-ui` 's native `Autocomplete` component instead of local `frappe-ui` Autocomplete component
- Update Filter component to support multi valued Autocomplete

## Testing Instructions

- Visit any page in next-crm with filters option
- Add a `In` or `Not In` filter 
- Test if the filter value can take multiple inputs

## Additional Information:

> [!NOTE]
> The filter should be of link type as only link type filters can have multiple values


## Screenshot/Screencast


https://github.com/user-attachments/assets/4a225fc7-e418-4579-a9c2-781ebcaa9981




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Addresses: https://github.com/rtCamp/erp-rtcamp/issues/2246