### PR TITLE
Fix customer modal not opening after route update

### DIFF
--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -527,7 +527,7 @@ import {
   call,
   usePageMeta,
 } from 'frappe-ui'
-import { ref, computed, h, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, h, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
 
@@ -761,7 +761,6 @@ const fieldsLayout = createResource({
   cache: ['fieldsLayout', props.opportunityId],
   params: { doctype: 'Opportunity', name: props.opportunityId },
   auto: true,
-  transform: (data) => getParsedFields(data),
 })
 
 function getParsedFields(sections) {
@@ -784,6 +783,15 @@ function getParsedFields(sections) {
   })
   return sections
 }
+
+watch(
+  () => fieldsLayout.data,
+  (data) => {
+    if (!data) return
+    const sections = getParsedFields(data)
+    fieldsLayout.data = sections
+  },
+)
 
 const showContactModal = ref(false)
 const showAddressModal = ref(false)


### PR DESCRIPTION
## Description

On going back and forth, the customer modal fails to open. This is due to transform not running again.
Instead of saving data through transform, we can parse fields on page load to refresh data appropriately, without requiring cache removal.

## Relevant Technical Choices

Moved transform to watch instead

## Testing Instructions

- [ ] Attempt to create new customer from opportunity
- [ ] Now go back and forward through browser controls, and attempt again
- [ ] Customer modal should open without fail


## Screenshot/Screencast


https://github.com/user-attachments/assets/7ec79b04-1deb-461e-bebb-180b9fd73dd4




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2222