### PR TITLE
Add patch to update CRM view settings filters

### DIFF
--- a/next_crm/patches.txt
+++ b/next_crm/patches.txt
@@ -14,3 +14,4 @@ next_crm.patches.v1_0.add_multiple_address_sidepanel_section
 next_crm.patches.v1_0.add_lead_contact_sidepanel_layout
 next_crm.patches.v1_0.modify_opportunity_existing_selection
 next_crm.patches.v1_0.update_won_date
+next_crm.patches.v1_0.update_crm_views_filters

--- a/next_crm/patches/v1_0/update_crm_views_filters.py
+++ b/next_crm/patches/v1_0/update_crm_views_filters.py
@@ -1,0 +1,56 @@
+import json
+
+import frappe
+from frappe.utils import update_progress_bar
+
+
+def execute():
+    # Get all CRM View Settings documents
+    crm_view_settings_list = frappe.get_all(
+        "CRM View Settings", fields=["name", "filters"]
+    )
+    total_settings = len(crm_view_settings_list)
+    for index, setting in enumerate(crm_view_settings_list):
+        name = setting.name
+        filters_str = setting.filters
+
+        if not filters_str or filters_str == "{}":
+            update_progress_bar("Updating CRM Views filters", index, total_settings)
+            continue
+
+        try:
+            filters = json.loads(filters_str)
+        except Exception as e:
+            frappe.log_error(
+                f"Failed to parse filters JSON in CRM View Settings {name}: {e}"
+            )
+            update_progress_bar("Updating CRM Views filters", index, total_settings)
+            continue
+
+        # Iterate through filters keys
+        for key, val in filters.items():
+            # Check if val is a list with operator "in"
+            if isinstance(val, list) and len(val) == 2 and val[0] == "in":
+                raw_values = val[1]
+
+                # Convert comma separated string to list, if necessary
+                if isinstance(raw_values, str):
+                    # Split by comma, strip spaces
+                    values_list = [v.strip() for v in raw_values.split(",")]
+                elif isinstance(raw_values, list):
+                    values_list = raw_values
+                else:
+                    # Unexpected format, skip
+                    update_progress_bar(
+                        "Updating CRM Views filters", index, total_settings
+                    )
+                    continue
+
+                # Update filter with corrected list
+                filters[key] = ["in", values_list]
+
+            # Save the updated filters back as JSON string
+            frappe.db.set_value(
+                "CRM View Settings", name, "filters", json.dumps(filters)
+            )
+        update_progress_bar("Updating CRM Views filters", index, total_settings)


### PR DESCRIPTION
## Description

With the new autocomplete and filter selection, CRM now expects filters options to be in array of strings format, not comma separated string.
This PR patches all CRM View Settings filters according to expected format.


## Testing Instructions

- [ ] Running bench migrate should update all filters


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)