### PR TITLE
Fix status label not visible in Kanban view

### DIFF
--- a/frontend/src/pages/Opportunities.vue
+++ b/frontend/src/pages/Opportunities.vue
@@ -137,11 +137,8 @@
             size="xs"
           />
         </div>
-        <div v-else-if="fieldName === 'probability'">
-          {{ getRow(itemName, fieldName).label }}%
-        </div>
         <div
-          v-else-if="
+          v-if="
             [
               'modified',
               'creation',
@@ -170,6 +167,9 @@
             :avatars="getRow(itemName, fieldName).label"
             size="xs"
           />
+        </div>
+        <div v-else-if="fieldName === 'probability'">
+          {{ getRow(itemName, fieldName).label }}%
         </div>
         <div v-else class="truncate text-base">
           {{ getRow(itemName, fieldName).label }}


### PR DESCRIPTION
## Description

Status field text is not visible in Kanban anymore.
This is due to the position of probability rendering condition.
This PR moves it to the right location to fix the issue.

## Testing Instructions

- [ ] Go to Kanban view
- [ ] Status should show label

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/c14240c4-be50-42b9-9cef-68a29a1ad3cd)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2287