### PR TITLE
Re-add customer creation from Prospect

### DIFF
--- a/frontend/src/pages/Customer.vue
+++ b/frontend/src/pages/Customer.vue
@@ -89,14 +89,14 @@
                 </div>
                 <div class="flex flex-col gap-2 truncate">
                   <div class="truncate text-2xl font-medium">
-                    <span>{{ customer.doc.name }}</span>
+                    <span>{{ customer.doc?.name }}</span>
                   </div>
                   <div
-                    v-if="customer.doc.website"
+                    v-if="customer.doc?.website"
                     class="flex items-center gap-1.5 text-base text-ink-gray-8"
                   >
                     <WebsiteIcon class="size-4" />
-                    <span>{{ website(customer.doc.website) }}</span>
+                    <span>{{ website(customer.doc?.website) }}</span>
                   </div>
                   <ErrorMessage :message="__(error)" />
                 </div>
@@ -226,7 +226,7 @@
   <LinkAddressModal
     v-model="showAddAddressModal"
     doctype="Customer",
-    :docname="customer.doc.name"
+    :docname="customer.doc?.name"
     :options="{
       afterAddAddress: afterAddAddress
     }"
@@ -234,7 +234,7 @@
   <LinkContactModal
     v-model="showAddContactModal"
     doctype="Customer",
-    :docname="customer.doc.name"
+    :docname="customer.doc?.name"
     :options="{
       afterAddContact: afterAddContact
     }"

--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -35,10 +35,10 @@
             label: __('Opportunity'),
             onClick: createOpportunity
           },
-          // {
-          //   label: __('Customer'),
-          //   onClick: createCustomer
-          // },
+          {
+            label: __('Customer'),
+            onClick: createCustomer
+          },
         ]"
         @click.stop
       >
@@ -208,6 +208,13 @@
       afterAddContact: afterAddContact
     }"
   />
+  <CustomerModal
+    v-model="showCustomerModal"
+    v-model:customer="_customer"
+    :options="{
+      redirect: true,
+    }"
+  />
 </template>
   
 <script setup>
@@ -251,6 +258,7 @@
     usePageMeta,
     createResource,
   } from 'frappe-ui'
+  import CustomerModal from '@/components/Modals/CustomerModal.vue'
   import { h, computed, ref } from 'vue'
   import { useRoute, useRouter } from 'vue-router'
   import { capture } from '@/telemetry'
@@ -269,7 +277,9 @@
   const showQuickEntryModal = ref(false)
   const showAddContactModal = ref(false)
   const showAddAddressModal = ref(false)
-  
+  const showCustomerModal = ref(false)
+  const _customer = ref({})
+
   const route = useRoute()
   const router = useRouter()
   
@@ -622,33 +632,12 @@ function getAddressRowObject(address) {
 }
 
 async function createCustomer() {
-  $dialog({
-    title: __('Create Customer'),
-    message: __('Are you sure you want to create a new Customer from this Prospect\'s details?'),
-    actions: [
-      {
-        label: __('Create'),
-        theme: 'green',
-        variant: 'solid',
-        async onClick(close) {
-          try {
-            const customer = await call('next_crm.overrides.prospect.create_customer', {
-              prospect: prospect.name,
-            })
-            close()
-            router.push({ name: 'Customer', params: { customerId: customer } })
-          } catch (error) {
-            createToast({
-              title: __('Error'),
-              text: error,
-              icon: 'x',
-              iconClasses: 'text-ink-red-4',
-            });
-          }
-        },
-      },
-    ],
-  })
+  _customer.value.customer_name = prospect.name
+  _customer.value.website = prospect.doc.website
+  _customer.value.no_of_employees = prospect.doc.no_of_employees
+  _customer.value.industry = prospect.doc.industry
+  _customer.value.territory = prospect.doc.territory
+  showCustomerModal.value = true
 }
 
 function addAddressButtonCB() {

--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -61,14 +61,14 @@
               <div class="flex gap-4 items-center">
                 <div class="flex flex-col gap-2 truncate">
                   <div class="truncate text-2xl font-medium text-ink-gray-9">
-                    <span>{{ prospect.doc.name }}</span>
+                    <span>{{ prospect.doc?.name }}</span>
                   </div>
                   <div
-                    v-if="prospect.doc.website"
+                    v-if="prospect.doc?.website"
                     class="flex items-center gap-1.5 text-base text-ink-gray-8"
                   >
                     <WebsiteIcon class="size-4" />
-                    <span>{{ website(prospect.doc.website) }}</span>
+                    <span>{{ website(prospect.doc?.website) }}</span>
                   </div>
                 </div>
               </div>
@@ -195,7 +195,7 @@
   <LinkAddressModal
     v-model="showAddAddressModal"
     doctype="Prospect"
-    :docname="prospect.doc.name"
+    :docname="prospect.doc?.name"
     :options="{
       afterAddAddress: afterAddAddress
     }"
@@ -203,7 +203,7 @@
   <LinkContactModal
     v-model="showAddContactModal"
     doctype="Prospect"
-    :docname="prospect.doc.name"
+    :docname="prospect.doc?.name"
     :options="{
       afterAddContact: afterAddContact
     }"

--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -637,6 +637,7 @@ async function createCustomer() {
   _customer.value.no_of_employees = prospect.doc.no_of_employees
   _customer.value.industry = prospect.doc.industry
   _customer.value.territory = prospect.doc.territory
+  _customer.value.annual_revenue = prospect.doc.annual_revenue
   showCustomerModal.value = true
 }
 

--- a/frontend/src/pages/Prospect.vue
+++ b/frontend/src/pages/Prospect.vue
@@ -210,10 +210,7 @@
   />
   <CustomerModal
     v-model="showCustomerModal"
-    v-model:customer="_customer"
-    :options="{
-      redirect: true,
-    }"
+    :customer="_customer"
   />
 </template>
   

--- a/next_crm/overrides/prospect.py
+++ b/next_crm/overrides/prospect.py
@@ -1,11 +1,7 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 import frappe
-from erpnext.crm.doctype.prospect.prospect import (
-    Prospect,
-    make_customer,
-    make_opportunity,
-)
+from erpnext.crm.doctype.prospect.prospect import Prospect, make_opportunity
 from frappe import _
 
 
@@ -80,16 +76,3 @@ def create_opportunity(prospect, doc=None):
     opportunity = make_opportunity(prospect.name)
     opportunity.insert()
     return opportunity.name
-
-
-@frappe.whitelist()
-def create_customer(prospect):
-    if not frappe.has_permission("Customer", "create"):
-        frappe.throw(
-            _("Not allowed to create Customer from Prospect"), frappe.PermissionError
-        )
-
-    prospect = frappe.get_cached_doc("Prospect", prospect)
-    customer = make_customer(prospect.name)
-    customer.insert()
-    return customer.name


### PR DESCRIPTION
## Description

Customer creation from Prospect was disabled due to mandatory field not present in Prospect.
Solution for which is to instead open Customer modal with pre-filled values, so that users can enter the mandatory fields before creation of Customer.

Apart form that, PR also solves an issue where page reload used to fail in Prospects. As it was created from Customers page it was also reproducible and originated from that page. Hence it is now fixed on both pages. 

## Testing Instructions

- [ ] Open prospect page
- [ ] Create a new Customer from Prospect
- [ ] Customer should be created and automatically redirected after that


## Screenshot/Screencast


https://github.com/user-attachments/assets/dba28f14-d1c9-4a84-9ee2-08998a7fd5af



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
