### PR TITLE
Do not make api call if doctype is not present

### DIFF
--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -175,6 +175,7 @@ const options = createResource({
 })
 
 function reload(val) {
+  if (!props.doctype) return
   if (options.data?.length && val === options.params?.txt && props.doctype === options.params?.doctype) return
 
   options.update({


### PR DESCRIPTION
## Description

This pr fixes issue with link field in crm, where even if the doctype is missing search_link is invoked resulting in 500 error,  this is resolved by adding doctype exists check before making a api call.

## Testing Instructions
1. Go to opportunity view.
2. Click on the Create button.
3. Observe the console, no error should be thrown for missing argument.


## Screenshot/Screencast

**Before**
![image](https://github.com/user-attachments/assets/b4a4ac80-a415-4472-8a7f-bdd416401140)

**After**
![image](https://github.com/user-attachments/assets/4b3f4391-0fad-4a59-8f5a-d1ef18d652c8)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->
