### PR TITLE
Fix not equals filter

### DIFF
--- a/frontend/src/components/Filter.vue
+++ b/frontend/src/components/Filter.vue
@@ -530,7 +530,7 @@ function parseFilters(filters) {
             ? false
             : Array.isArray(c.value)
               ? ['!=', c.value[c.value.length - 1]]
-              : c.value
+              : ['!=', c.value]
     } else {
       p[c.fieldname] = [operatorMap[c.operator.toLowerCase()], c.value]
     }


### PR DESCRIPTION
## Description

This PR fixes `Not equals` filter to get applied due to missing `not-equals` operator

## Relevant Technical Choices

- Add not-equals operator when parsing filters

## Testing Instructions

- Got to next-crm 
- Apply `Not-Equals` filter

## Additional Information:

> N/A

## Screenshot/Screencast

> N/A


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes https://github.com/rtCamp/erp-rtcamp/issues/2299