### PR TITLE
Add InfoLog comments in activity for opportunity

### DIFF
--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -128,6 +128,18 @@ def get_opportunity_activities(name):
         }
         activities.append(activity)
 
+    for info_log in docinfo.info_logs:
+        activity = {
+            "name": info_log.name,
+            "activity_type": "comment",
+            "creation": info_log.creation,
+            "owner": info_log.owner,
+            "content": info_log.content,
+            "attachments": get_attachments("Comment", info_log.name),
+            "is_lead": False,
+        }
+        activities.append(activity)
+
     for communication in docinfo.communications + docinfo.automated_messages:
         activity = {
             "activity_type": "communication",


### PR DESCRIPTION
## Description

This PR updates the `get_opportunity_activities` API to include InfoLogs comments in the response.


## Relevant Technical Choices

- Append InfoLog comments in activity list.

## Testing Instructions

- Add Info type comment  in opportunity
- It should also be visible on next-crm activity tab

## Additional Information:

> N/A

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/15e2b7be-0b00-430b-b44a-02f19aa6f748)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
