### PR TITLE
reload activities on opportunity lost

### DIFF
--- a/frontend/src/components/Modals/LostReasonModal.vue
+++ b/frontend/src/components/Modals/LostReasonModal.vue
@@ -91,6 +91,12 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  options: {
+    type: Object,
+    default: {
+      afterLostReason: () => {},
+    },
+  },
 })
 const emit = defineEmits(['reload'])
 
@@ -154,6 +160,7 @@ const updateOpportunity = async () => {
       detailed_reason: detailedReason.value,
     })
     props.opportunity.reload()
+    props.options.afterLostReason()
     createToast({
       title: __('Opportunity updated'),
       icon: 'check',

--- a/frontend/src/components/Modals/LostReasonModal.vue
+++ b/frontend/src/components/Modals/LostReasonModal.vue
@@ -91,14 +91,8 @@ const props = defineProps({
     type: Object,
     required: true,
   },
-  options: {
-    type: Object,
-    default: {
-      afterLostReason: () => {},
-    },
-  },
 })
-const emit = defineEmits(['reload'])
+const emit = defineEmits(['reload', 'after-lost-reason'])
 
 const show = defineModel()
 const detailedReason = ref('')
@@ -160,7 +154,7 @@ const updateOpportunity = async () => {
       detailed_reason: detailedReason.value,
     })
     props.opportunity.reload()
-    props.options.afterLostReason()
+    emit('after-lost-reason')
     createToast({
       title: __('Opportunity updated'),
       icon: 'check',

--- a/frontend/src/components/Modals/LostReasonModal.vue
+++ b/frontend/src/components/Modals/LostReasonModal.vue
@@ -92,7 +92,7 @@ const props = defineProps({
     required: true,
   },
 })
-const emit = defineEmits(['reload', 'after-lost-reason'])
+const emit = defineEmits(['reload'])
 
 const show = defineModel()
 const detailedReason = ref('')
@@ -154,7 +154,7 @@ const updateOpportunity = async () => {
       detailed_reason: detailedReason.value,
     })
     props.opportunity.reload()
-    emit('after-lost-reason')
+    emit('reload')
     createToast({
       title: __('Opportunity updated'),
       icon: 'check',

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -471,7 +471,7 @@
     v-if="opportunity?.data?.name"
     v-model="showLostReasonModal"
     :opportunity="opportunity"
-    @after-lost-reason="() => reload = true"
+    @reload="() => reload = true"
   />
 </template>
 <script setup>

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -467,7 +467,7 @@
         afterRename: afterRename
       }"
   />
-  <LostReasonModal 
+  <LostReasonModal
     v-if="opportunity?.data?.name"
     v-model="showLostReasonModal"
     :opportunity="opportunity"

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -471,13 +471,7 @@
     v-if="opportunity?.data?.name"
     v-model="showLostReasonModal"
     :opportunity="opportunity"
-    :options = "
-      {
-        afterLostReason: () => {
-          reload = true
-          showLostReasonModal = false
-        }
-      }"
+    @after-lost-reason="() => reload = true"
   />
 </template>
 <script setup>

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -467,7 +467,18 @@
         afterRename: afterRename
       }"
   />
-  <LostReasonModal v-if="opportunity?.data?.name" v-model="showLostReasonModal" :opportunity="opportunity"/>
+  <LostReasonModal 
+    v-if="opportunity?.data?.name"
+    v-model="showLostReasonModal"
+    :opportunity="opportunity"
+    :options = "
+      {
+        afterLostReason: () => {
+          reload = true
+          showLostReasonModal = false
+        }
+      }"
+  />
 </template>
 <script setup>
 import Icon from '@/components/Icon.vue'


### PR DESCRIPTION
## Description

Currently, setting an opportunity as lost doesn't update activities, and has to be refreshed manually,
This PR updates opportunity like other status updates.

## Relevant Technical Choices

triggering reload through a after execute function on lost reason.

## Testing Instructions

- [ ] Set an opportunity as lost
- [ ] The page activities should reload


## Screenshot/Screencast


https://github.com/user-attachments/assets/e385e784-e38d-4cda-9e7b-6ff9be157420




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)