### PR TITLE
Parse link filters for link field

### DIFF
--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -158,12 +158,12 @@ const options = createResource({
     filters: parse_filters(props.filters),
   },
   transform: (data) => {
-    let allData = data.map((option) => {
-      return {
-        label: option.value,
+    let allData = data
+      .map((option) => ({
+        label: option.description || option.value,
         value: option.value,
-      }
-    })
+      }))
+      .filter((option, index, self) => index === self.findIndex((t) => t.value === option.value))
     if (!props.hideMe && props.doctype == 'User') {
       allData.unshift({
         label: '@me',

--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -185,12 +185,25 @@ function parse_filters(link_filters) {
         parent: this.doc.parenttype ? this.frm.doc : null,
         frappe,
       }
-      value = frappe.utils.eval(value, context)
+      value = evalFilter(value, context)
     }
     filters[fieldname] = [operator, value]
   })
 
   return filters
+}
+function evalFilter(code, context = {}) {
+  let variable_names = Object.keys(context)
+  let variables = Object.values(context)
+  code = `let out = ${code}; return out`
+  try {
+    let expression_function = new Function(...variable_names, code)
+    return expression_function(...variables)
+  } catch (error) {
+    console.log('Error evaluating the following expression:')
+    console.error(code)
+    throw error
+  }
 }
 function reload(val) {
   if (!props.doctype) return


### PR DESCRIPTION
## Description

This pr adds a validation function which checks the `link_filters` used by the Link fields and convert them into acceptable format by the API. Insuring api receives filters in correct format.

## Relevant Technical Choices

- Parse filters if it is array type

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

See 
- https://github.com/rtCamp/erp-rtcamp/issues/2255

