### PR TITLE
Show modal on attempting to update "Opportunity From"

### DIFF
--- a/frontend/src/components/Modals/OpportunityFromSetModal.vue
+++ b/frontend/src/components/Modals/OpportunityFromSetModal.vue
@@ -1,0 +1,121 @@
+<template>
+  <Dialog
+    v-model="show"
+    :options="{
+      title: __('Set Opportunity From'),
+      size: 'md',
+      actions: [
+        {
+          label: __('Save'),
+          variant: 'solid',
+          onClick: setOpportunityFrom,
+        },
+      ],
+    }"
+  >
+    <template #body-content>
+      <div>
+        <Select
+          class="form-control"
+          label="Opportunity From"
+          :options="[
+            {
+              label: 'Lead',
+              value: 'Lead',
+            },
+            {
+              label: 'Customer',
+              value: 'Customer',
+            },
+            {
+              label: 'Prospect',
+              value: 'Prospect',
+            },
+          ]"
+          v-model="_opportunity_fields.opportunity_from"
+        />
+      </div>
+      <div class="mt-6">
+        <Link
+          class="form-control"
+          label="Party Name"
+          :value="_opportunity_fields.party_name"
+          :doctype="_opportunity_fields.opportunity_from"
+          @change="(option) => (_opportunity_fields.party_name = option)"
+          :placeholder="__('Party Name')"
+          :hideMe="false"
+        >
+        </Link>
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup>
+import { ref, nextTick, watch, reactive } from 'vue'
+import { createToast } from '@/utils'
+import { call, Select } from 'frappe-ui'
+import Link from '@/components/Controls/Link.vue'
+
+const props = defineProps({
+  opportunity_from: {
+    type: String,
+    default: '',
+  },
+  party_name: {
+    type: String,
+    default: '',
+  },
+  docname: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits(['after'])
+
+const _opportunity_fields = reactive({
+  opportunity_from: '',
+  party_name: '',
+})
+
+const show = defineModel()
+
+async function setOpportunityFrom() {
+  try {
+    await call('frappe.client.set_value', {
+      doctype: 'Opportunity',
+      name: props.docname,
+      fieldname: {
+        opportunity_from: _opportunity_fields.opportunity_from,
+        party_name: _opportunity_fields.party_name,
+      },
+    })
+    show.value = false
+    createToast({
+      title: __(`Opportunity Updated`),
+      icon: 'check',
+      iconClasses: 'text-ink-green-4',
+    })
+    emit('after')
+  } catch (error) {
+    createToast({
+      title: __('Error'),
+      text: error,
+      icon: 'x',
+      iconClasses: 'text-ink-red-4',
+    })
+  }
+}
+
+watch(
+  () => show.value,
+  (value) => {
+    if (!value) return
+    nextTick(() => {
+      _opportunity_fields.opportunity_from = props.opportunity_from
+      _opportunity_fields.party_name = props.party_name
+    })
+  },
+)
+</script>

--- a/frontend/src/components/Modals/OpportunityFromSetModal.vue
+++ b/frontend/src/components/Modals/OpportunityFromSetModal.vue
@@ -32,18 +32,17 @@
               value: 'Prospect',
             },
           ]"
-          v-model="_opportunity_fields.opportunity_from"
+          v-model="_opportunityFields.opportunityFrom"
         />
       </div>
       <div class="mt-6">
         <Link
           class="form-control"
           label="Party Name"
-          :value="_opportunity_fields.party_name"
-          :doctype="_opportunity_fields.opportunity_from"
-          @change="(option) => (_opportunity_fields.party_name = option)"
+          :value="_opportunityFields.partyName"
+          :doctype="_opportunityFields.opportunityFrom"
+          @change="(option) => (_opportunityFields.partyName = option)"
           :placeholder="__('Party Name')"
-          :hideMe="false"
         >
         </Link>
       </div>
@@ -58,13 +57,12 @@ import { call, Select } from 'frappe-ui'
 import Link from '@/components/Controls/Link.vue'
 
 const props = defineProps({
-  opportunity_from: {
-    type: String,
-    default: '',
-  },
-  party_name: {
-    type: String,
-    default: '',
+  opportunityFrom: {
+    type: Object,
+    default: {
+      opportunityFrom: 'Lead',
+      partyName: '',
+    },
   },
   docname: {
     type: String,
@@ -74,9 +72,9 @@ const props = defineProps({
 
 const emit = defineEmits(['after'])
 
-const _opportunity_fields = reactive({
-  opportunity_from: '',
-  party_name: '',
+const _opportunityFields = reactive({
+  opportunityFrom: '',
+  partyName: '',
 })
 
 const show = defineModel()
@@ -87,8 +85,8 @@ async function setOpportunityFrom() {
       doctype: 'Opportunity',
       name: props.docname,
       fieldname: {
-        opportunity_from: _opportunity_fields.opportunity_from,
-        party_name: _opportunity_fields.party_name,
+        opportunity_from: _opportunityFields.opportunityFrom,
+        party_name: _opportunityFields.partyName,
       },
     })
     show.value = false
@@ -113,8 +111,8 @@ watch(
   (value) => {
     if (!value) return
     nextTick(() => {
-      _opportunity_fields.opportunity_from = props.opportunity_from
-      _opportunity_fields.party_name = props.party_name
+      _opportunityFields.opportunityFrom = props.opportunityFrom.opportunityFrom
+      _opportunityFields.partyName = props.opportunityFrom.partyName
     })
   },
 )

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -473,6 +473,16 @@
     :opportunity="opportunity"
     @reload="() => reload = true"
   />
+  <OpportunityFromSetModal
+    v-model="showOpportunityFromModal"
+    :opportunity_from="opportunityFrom"
+    :title="opportunity?.data?.party_name"
+    :docname="opportunity?.data?.name"
+    @after="() => {
+      opportunity.reload()
+      reload = true
+    }"
+  />
 </template>
 <script setup>
 import Icon from '@/components/Icon.vue'
@@ -504,6 +514,7 @@ import ContactModal from '@/components/Modals/ContactModal.vue'
 import SidePanelModal from '@/components/Settings/SidePanelModal.vue'
 import RenameModal from '@/components/Modals/RenameModal.vue'
 import LostReasonModal from '@/components/Modals/LostReasonModal.vue'
+import OpportunityFromSetModal from '../components/Modals/OpportunityFromSetModal.vue'
 import Link from '@/components/Controls/Link.vue'
 import Section from '@/components/Section.vue'
 import SectionFields from '@/components/SectionFields.vue'
@@ -616,6 +627,8 @@ const showCustomerModal = ref(false)
 const showSidePanelModal = ref(false)
 const showFilesUploader = ref(false)
 const showRenameModal = ref(false)
+const showOpportunityFromModal = ref(false)
+const opportunityFrom = ref(opportunity?.data?.opportunity_from)
 const _customer = ref({})
 const showLostReasonModal =  ref (false)
 
@@ -623,6 +636,12 @@ function updateOpportunity(fieldname, value, callback) {
   value = Array.isArray(fieldname) ? '' : value
 
   if (validateRequired(fieldname, value)) return
+
+  if (fieldname == 'opportunity_from') {
+    opportunityFrom.value = value
+    showOpportunityFromModal.value = true
+    return
+  }
 
   createResource({
     url: 'frappe.client.set_value',

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -475,7 +475,7 @@
   />
   <OpportunityFromSetModal
     v-model="showOpportunityFromModal"
-    :opportunity_from="opportunityFrom"
+    :opportunityFrom="opportunityFrom"
     :title="opportunity?.data?.party_name"
     :docname="opportunity?.data?.name"
     @after="() => {
@@ -543,7 +543,7 @@ import {
   call,
   usePageMeta,
 } from 'frappe-ui'
-import { ref, computed, h, onMounted, onBeforeUnmount, watch } from 'vue'
+import { ref, computed, h, onMounted, onBeforeUnmount, watch, reactive } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
 
@@ -628,7 +628,10 @@ const showSidePanelModal = ref(false)
 const showFilesUploader = ref(false)
 const showRenameModal = ref(false)
 const showOpportunityFromModal = ref(false)
-const opportunityFrom = ref(opportunity?.data?.opportunity_from)
+const opportunityFrom = reactive({
+  opportunityFrom: opportunity?.data?.opportunity_from,
+  partyName: opportunity?.data?.party_name,
+})
 const _customer = ref({})
 const showLostReasonModal =  ref (false)
 
@@ -637,8 +640,8 @@ function updateOpportunity(fieldname, value, callback) {
 
   if (validateRequired(fieldname, value)) return
 
-  if (fieldname == 'opportunity_from') {
-    opportunityFrom.value = value
+  if (fieldname == 'opportunity_from' || fieldname == 'party_name') {
+    fieldname == 'opportunity_from' ? opportunityFrom.opportunityFrom = value : opportunityFrom.partyName = value
     showOpportunityFromModal.value = true
     return
   }


### PR DESCRIPTION
## Description

Currently, `Opportunity From`  is not editable from frontend due to `Party Name` being reliant on it.
This can be fixed by introducing a modal to bypass the automatic save and giving users opportunity to update the party name

The model will be pre-filled with values to save clicks.

## Relevant Technical Choices
Added new modal for changing opportunity from

## Testing Instructions

- [ ] Open opportunity
- [ ] Attempt to change opportunity from or party name

## Screenshot/Screencast

https://github.com/user-attachments/assets/2021779b-7d9a-4640-9c95-eb906a2de218




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2265