### PR TITLE
Hide comments tab

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -592,12 +592,24 @@ watch([reload, reload_email], ([reload_value, reload_email_value]) => {
 watch(
   () => all_activities.data,
   (value) => {
-    props.tabs[1].count.value = value?.versions.filter((activity) => activity.activity_type === 'communication').length
-    props.tabs[2].count.value = value?.versions.filter((activity) => activity.activity_type === 'comment').length
-    props.tabs[3].count.value = value?.todos.length
-    props.tabs[4].count.value = value?.events.length
-    props.tabs[5].count.value = value?.notes.length
-    props.tabs[6].count.value = value?.attachments.length
+    const getActivityCount = (type) =>
+      value?.versions?.filter((activity) => activity.activity_type === type).length || 0
+
+    const tabCounts = {
+      Emails: getActivityCount('communication'),
+      Comments: getActivityCount('comment'),
+      ToDos: value?.todos?.length || 0,
+      Events: value?.events?.length || 0,
+      Notes: value?.notes?.length || 0,
+      Attachments: value?.attachments?.length || 0,
+    }
+
+    for (const [name, count] of Object.entries(tabCounts)) {
+      const tab = props.tabs.find((t) => t.name === name)
+      if (tab) {
+        tab.count.value = count
+      }
+    }
   },
 )
 

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -955,7 +955,7 @@ const tabs = computed(() => {
       label: __('Comments'),
       icon: CommentIcon,
       count: ref(0),
-      condition: () => lead?.custom_hide_comments_tab,
+      condition: () => !Boolean(lead?.data?.hide_comments_tab),
     },
     {
       name: 'Calls',

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -954,7 +954,8 @@ const tabs = computed(() => {
       name: 'Comments',
       label: __('Comments'),
       icon: CommentIcon,
-      count: ref(0)
+      count: ref(0),
+      condition: () => lead?.custom_hide_comments_tab,
     },
     {
       name: 'Calls',

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -711,7 +711,8 @@ const tabs = computed(() => {
       name: 'Comments',
       label: __('Comments'),
       icon: CommentIcon,
-      count: ref(0)
+      count: ref(0),
+      condition: () => opportunity?.custom_hide_comments_tab,
     },
     {
       name: 'Calls',

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -712,7 +712,7 @@ const tabs = computed(() => {
       label: __('Comments'),
       icon: CommentIcon,
       count: ref(0),
-      condition: () => opportunity?.custom_hide_comments_tab,
+      condition: () => !Boolean(opportunity?.data?.hide_comments_tab),
     },
     {
       name: 'Calls',

--- a/next_crm/api/lead.py
+++ b/next_crm/api/lead.py
@@ -20,4 +20,6 @@ def get_lead(name):
     lead["fields_meta"] = get_fields_meta("Lead")
     lead["_form_script"] = get_form_script("Lead")
     lead["_assign"] = get_assigned_users("Lead", lead.name)
+    hide_comments_tab = frappe.db.get_single_value("NCRM Settings", "hide_comments_tab")
+    lead["hide_comments_tab"] = hide_comments_tab
     return lead

--- a/next_crm/api/opportunity.py
+++ b/next_crm/api/opportunity.py
@@ -13,6 +13,8 @@ def get_opportunity(name):
     opportunity["fields_meta"] = get_fields_meta("Opportunity")
     opportunity["_form_script"] = get_form_script("Opportunity")
     opportunity["_assign"] = get_assigned_users("Opportunity", opportunity.name)
+    hide_comments_tab = frappe.db.get_single_value("NCRM Settings", "hide_comments_tab")
+    opportunity["hide_comments_tab"] = hide_comments_tab
     return opportunity
 
 

--- a/next_crm/ncrm/doctype/ncrm_settings/ncrm_settings.json
+++ b/next_crm/ncrm/doctype/ncrm_settings/ncrm_settings.json
@@ -1,40 +1,45 @@
 {
- "actions": [],
- "allow_rename": 1,
- "creation": "2024-09-29 13:48:02.715924",
- "doctype": "DocType",
- "engine": "InnoDB",
- "field_order": [
-  "restore_defaults"
- ],
- "fields": [
-  {
-   "fieldname": "restore_defaults",
-   "fieldtype": "Button",
-   "label": "Restore Defaults"
-  }
- ],
- "index_web_pages_for_search": 1,
- "issingle": 1,
- "links": [],
- "modified": "2024-09-29 13:49:07.835379",
- "modified_by": "Administrator",
- "module": "NCRM",
- "name": "NCRM Settings",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  }
- ],
- "sort_field": "creation",
- "sort_order": "DESC",
- "states": []
+  "actions": [],
+  "allow_rename": 1,
+  "creation": "2024-09-29 13:48:02.715924",
+  "doctype": "DocType",
+  "engine": "InnoDB",
+  "field_order": ["restore_defaults", "hide_comments_tab"],
+  "fields": [
+    {
+      "fieldname": "restore_defaults",
+      "fieldtype": "Button",
+      "label": "Restore Defaults"
+    },
+    {
+      "default": "1",
+      "description": "This flag controls the visibility of the comments section in next-crm for opportunity and Lead",
+      "fieldname": "hide_comments_tab",
+      "fieldtype": "Check",
+      "label": "Hide Comments Tab"
+    }
+  ],
+  "index_web_pages_for_search": 1,
+  "issingle": 1,
+  "links": [],
+  "modified": "2025-05-23 10:51:30.482563",
+  "modified_by": "Administrator",
+  "module": "NCRM",
+  "name": "NCRM Settings",
+  "owner": "Administrator",
+  "permissions": [
+    {
+      "create": 1,
+      "delete": 1,
+      "email": 1,
+      "print": 1,
+      "read": 1,
+      "role": "System Manager",
+      "share": 1,
+      "write": 1
+    }
+  ],
+  "sort_field": "creation",
+  "sort_order": "DESC",
+  "states": []
 }


### PR DESCRIPTION
## Description

This PR hides the `Comments` tab in Lead and Opportunity views by introducing a boolean flag in NCRM settings called `Hide Comments Tab` . Users can now control the visibility of the comments section dynamically.

## Relevant Technical Choices

- Add `Hide Comments Tab` check field in NCRM Settings
- Update Frontend to support conditional rendering

## Testing Instructions

- Go to NCRM Settings
- Check `Hide Comments Tab` (if not already checked)
- Open a Opportunity/Lead
- Comments Section should no longer be visible for both opportunity and leads

## Additional Information:

> N/A

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/24b6aaa0-5fac-420b-82ec-c23413f1db38)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Addresses: https://github.com/rtCamp/erp-rtcamp/issues/2309