### PR TITLE
Add notes to activity stream

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -120,7 +120,7 @@
           <CommentArea :activity="activity" />
         </div>
         <div v-else-if="activity.activity_type == 'note'">
-          <div class="mb-4 cursor-pointer" @click="modalRef.showNote(activity)">
+          <div class="mb-4 cursor-pointer text-base" @click="modalRef.showNote(activity)">
             <div class="mb-1 flex items-center justify-stretch gap-2 py-1 text-base">
               <div class="inline-flex items-center flex-wrap gap-1 text-ink-gray-5">
                 <UserAvatar :user="activity.owner" size="md" class="mr-1" />


### PR DESCRIPTION
## Description

This PR adds `Notes` in activity stream for better accessibility.

## Relevant Technical Choices

- Add additional `note` type  to render notes in activity and refactor computed `activities` to support changes

## Testing Instructions

- Open opportunity / lead
- Add a note (if you have 0 notes)
- Observe Activity timeline

## Additional Information:

> N/A

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/7e7d0bc3-ba8a-4189-bc2f-f12995352c60)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Addresses: https://github.com/rtCamp/erp-rtcamp/issues/2308#event-17769072715