### PR TITLE
Fix autocomplete close function

### DIFF
--- a/frontend/src/components/Controls/Link.vue
+++ b/frontend/src/components/Controls/Link.vue
@@ -30,13 +30,13 @@
         <slot name="item-label" v-bind="{ active, selected, option }" />
       </template>
 
-      <template #footer="{ value, close }">
+      <template #footer="{ value, togglePopover }">
         <div v-if="attrs.onCreate">
           <Button
             variant="ghost"
             class="w-full !justify-start"
             :label="__('Create New')"
-            @click="attrs.onCreate(value, close)"
+            @click="attrs.onCreate(value, togglePopover)"
           >
             <template #prefix>
               <FeatherIcon name="plus" class="h-4" />
@@ -44,7 +44,12 @@
           </Button>
         </div>
         <div>
-          <Button variant="ghost" class="w-full !justify-start" :label="__('Clear')" @click="() => clearValue(close)">
+          <Button
+            variant="ghost"
+            class="w-full !justify-start"
+            :label="__('Clear')"
+            @click="() => clearValue(togglePopover)"
+          >
             <template #prefix>
               <FeatherIcon name="x" class="h-4" />
             </template>


### PR DESCRIPTION
## Description

This PR aims to fix popover close function for autocomplete.

## Relevant Technical Choices

- Replace `close` to `togglePopover` to correctly bind with popover `Open/Closing` states.

## Testing Instructions

- Go to opportunity
- Click on Customer
- Click on `Create new` / Clear
- The AutoComplete Popover should get closed

## Additional Information:

> N/A

## Screenshot/Screencast

[Fix autocomplete close-1748243484393.webm](https://github.com/user-attachments/assets/31c42dea-dc23-495b-9d88-f60bcf2d7279)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
