### PR TITLE
Hide Comments From ActivityHeader and Communication Area

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -456,6 +456,11 @@ const activities = computed(() => {
   let _activities = []
   if (title.value == 'Activity') {
     _activities = get_activities()
+
+    if (Boolean(doc?.value?.data?.hide_comments_tab)) {
+      _activities = _activities.filter((activity) => activity.activity_type !== 'comment')
+    }
+
     const notesAsActivities = (all_activities.data?.notes || []).map((note) => ({
       ...note,
       activity_type: 'note',

--- a/frontend/src/components/Activities/ActivityHeader.vue
+++ b/frontend/src/components/Activities/ActivityHeader.vue
@@ -109,6 +109,7 @@ const defaultActions = computed(() => {
       icon: h(CommentIcon, { class: 'h-4 w-4' }),
       label: __('New Comment'),
       onClick: () => (props.emailBox.showComment = true),
+      condition: () => !Boolean(props.doc?.data?.hide_comments_tab),
     },
     {
       icon: h(PhoneIcon, { class: 'h-4 w-4' }),

--- a/frontend/src/components/CommunicationArea.vue
+++ b/frontend/src/components/CommunicationArea.vue
@@ -14,6 +14,7 @@
       </Button>
       <Button
         variant="ghost"
+        v-if="doc?.data.hide_comments_tab !== 1"
         :label="__('Comment')"
         :class="[showCommentBox ? '!bg-surface-gray-4 hover:!bg-surface-gray-3' : '']"
         @click="toggleCommentBox()"


### PR DESCRIPTION
## Description

This PR hides comment related Action buttons from `ActivityHeader` and `Communication Area` and also remove comment from activity timeline.

## Relevant Technical Choices

- Add Check in `ActivityHeader` and `Communication Area` to render Comment Action buttons and Comments in activity timeline.

## Testing Instructions

- Go to Lead/Opportunity
- If `Hide Comments Tab` is checked all Comment related Action Buttons should  not be visible

## Additional Information:

> N/A

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/b0a731ed-9a2d-4bf1-9595-33519f714d71)

![image](https://github.com/user-attachments/assets/9eeda25f-a469-4162-a576-f8f994663f3f)

![image](https://github.com/user-attachments/assets/885b3f94-0360-4021-9714-f93052266903)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Addresses https://github.com/rtCamp/erp-rtcamp/issues/2309#event-17769115067