### PR TITLE
Automatically link gmail thread when Opportunity is created from Lead

### DIFF
--- a/next_crm/overrides/opportunity.py
+++ b/next_crm/overrides/opportunity.py
@@ -20,6 +20,7 @@ from next_crm.ncrm.doctype.crm_stage_change_log.crm_stage_change_log import (
 from next_crm.ncrm.doctype.crm_status_change_log.crm_status_change_log import (
     add_status_change_log,
 )
+from next_crm.utils import link_gmail_threads
 
 
 class OverrideOpportunity(Opportunity):
@@ -53,6 +54,8 @@ class OverrideOpportunity(Opportunity):
             ):
                 copy_comments(self.opportunity_from, self.party_name, self)
                 link_communications(self.opportunity_from, self.party_name, self)
+                if "frappe_gmail_thread" in frappe.get_installed_apps():
+                    link_gmail_threads(self.opportunity_from, self.party_name, self)
         self.set_primary_email_mobile_no()
 
     def before_save(self):

--- a/next_crm/utils/__init__.py
+++ b/next_crm/utils/__init__.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import frappe
 from frappe.utils import get_datetime
 
 
@@ -10,3 +11,22 @@ def get_duration(from_date, to_date):
         to_date = get_datetime(to_date)
     duration = to_date - from_date
     return duration.total_seconds()
+
+
+def link_gmail_threads(doctype, docname, doc):
+    gmail_thread_list = get_linked_gmail_thread_list(doctype, docname)
+
+    for gmail_thread in gmail_thread_list:
+        gmail_thread_doc = frappe.get_doc("Gmail Thread", gmail_thread)
+        gmail_thread_doc.reference_doctype = doc.doctype
+        gmail_thread_doc.reference_name = doc.name
+        gmail_thread_doc.save()
+
+
+def get_linked_gmail_thread_list(doctype, docname):
+    gmail_threads = frappe.get_all(
+        "Gmail Thread",
+        filters={"reference_doctype": doctype, "reference_name": docname},
+        pluck="name",
+    )
+    return gmail_threads


### PR DESCRIPTION
## Description

- Automatically link gmail threads to Opportunity created from Lead, if any gmail thread were linked to the original Lead.
- Only do this if `carry_forward_communication_and_comments` is enabled in `CRM Settings`

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [ ] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [ ] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes #