### PR TITLE
Link opportunity to project during creation

### DIFF
--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -938,9 +938,18 @@ const OPPORTUNITY_TO_PROJECT_KEY_MAP = {
 
 const createProject = async (projectData) => {
   try {
+    const data = await call('frappe.desk.form.load.getdoctype', {
+      doctype: 'Project',
+    })
+    const projectMeta = data?.docs?.find(doc => doc.name === 'Project')
+    const hasCustomOpportunity = projectMeta?.fields?.some(item => item.fieldname === 'custom_opportunity')
+    
     const projectPayload = {
       project_name: projectData.title,
-      status: "Open"
+      status: "Open",
+      ...(hasCustomOpportunity && {
+        custom_opportunity: props.opportunityId
+      })
     };
 
     Object.entries(OPPORTUNITY_TO_PROJECT_KEY_MAP).forEach(([sourceKey, targetKey]) => {
@@ -959,8 +968,8 @@ const createProject = async (projectData) => {
     showCreateProjectModal.value = false;
   } catch{
     createToast({
-      title: __(projectResource.error.exc_type || 'Error creating project'),
-      text: __(projectResource.error.messages[0] || 'Something went wrong'),
+      title: __(projectResource?.error?.exc_type || 'Error creating project'),
+      text: __(projectResource?.error?.messages[0] || 'Something went wrong'),
       icon: 'x',
       iconClasses: 'text-ink-red-4',
     })

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -383,6 +383,7 @@ import {
 import { ref, computed, h, onMounted, onBeforeUnmount, watch, reactive } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
+import { getMeta } from '@/stores/meta'
 
 const { $dialog, $socket, makeCall } = globalStore()
 const { statusOptions, getDealStatus } = statusesStore()
@@ -938,12 +939,9 @@ const OPPORTUNITY_TO_PROJECT_KEY_MAP = {
 
 const createProject = async (projectData) => {
   try {
-    const data = await call('frappe.desk.form.load.getdoctype', {
-      doctype: 'Project',
-    })
-    const projectMeta = data?.docs?.find(doc => doc.name === 'Project')
-    const hasCustomOpportunity = projectMeta?.fields?.some(item => item.fieldname === 'custom_opportunity')
-    
+    const { getFields } = await getMeta("Project");
+    const projectMeta = getFields();
+    const hasCustomOpportunity = projectMeta?.some(item => item.fieldname === 'custom_opportunity');
     const projectPayload = {
       project_name: projectData.title,
       status: "Open",


### PR DESCRIPTION
## Description

This PR links opportunity to project via `custom_opportunity` field  when creating a new project from an opportunity.

## Relevant Technical Choices

- links current opportunity to the created project

## Testing Instructions

- Change status to won for an opportunity
- Open created project
- Navigate to Project Tracking tab
- The `custom_opportunity` field should point to the parent opportunity

## Additional Information:

> N/A

## Screenshot/Screencast

> N/A


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
