### PR TITLE
Add sanitize Currency utility to fix currency cell filter

### DIFF
--- a/frontend/src/components/ViewControls.vue
+++ b/frontend/src/components/ViewControls.vue
@@ -257,7 +257,7 @@ import { globalStore } from '@/stores/global'
 import { viewsStore } from '@/stores/views'
 import { usersStore } from '@/stores/users'
 import { getMeta } from '@/stores/meta'
-import { isEmoji, createToast } from '@/utils'
+import { isEmoji, createToast, sanitizeCurrency } from '@/utils'
 import { setDefaultViewCache } from '@/utils/view'
 import { Tooltip, createResource, Dropdown, call, FeatherIcon, usePageMeta } from 'frappe-ui'
 import { computed, ref, onMounted, watch, h, markRaw } from 'vue'
@@ -1198,6 +1198,9 @@ function applyFilter({ event, idx, column, item, firstColumn }) {
   if (value) {
     if (column.type == 'Link') {
       filters[column.key] = ['in', Array.isArray(value) ? value : [value]]
+    } else if (column.type == 'Currency') {
+      const sanitizedCurrencyValue = sanitizeCurrency(value)
+      filters[column.key] = sanitizedCurrencyValue
     } else {
       filters[column.key] = value
     }

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -323,3 +323,7 @@ export const debounce = (fn, delay) => {
       }, delay);
   };
 }
+
+export const sanitizeCurrency = (str) => {
+  return str.replace(/[^\d.-]/g, '');
+}


### PR DESCRIPTION
## Description

This PR addresses an issue in the NCRM List View where clicking on a column cell containing special characters (such as currency symbols like ₹, $, etc.) fails to apply the expected equals (=) filter.

## Relevant Technical Choices

- Sanitized cell values before applying the `= `filter.
- Added utility function to strip non-alphanumeric/filterable characters from the cell value.

## Testing Instructions

1. Go to Opportunity list view.
2. Add Amount column if not already added.
3. Click on any cell containing some amount.
4. Equals filter should be applied correctly

## Additional Information:

> N/A

## Screenshot/Screencast

[Currency Cell filter.webm](https://github.com/user-attachments/assets/1f67bf9f-4d52-4519-9c20-87b0fe6a6f7d)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Addresses https://github.com/rtCamp/next-crm/issues/229