### PR TITLE
Fix empty note key when creating empty body notes

### DIFF
--- a/frontend/src/components/CommunicationArea.vue
+++ b/frontend/src/components/CommunicationArea.vue
@@ -310,7 +310,7 @@ const newNoteEditor = ref(null)
 const noteParent = ref('')
 
 const noteEmpty = computed(() => {
-  return !newNoteContent.value || newNoteContent.value === '<p></p>'
+  return !newNoteTitle.value && (!newNoteContent.value || newNoteContent.value === '<p></p>')
 })
 
 function toggleNoteBox() {

--- a/frontend/src/components/Modals/NoteModal.vue
+++ b/frontend/src/components/Modals/NoteModal.vue
@@ -102,7 +102,7 @@ async function updateNote() {
         doctype: props.doctype,
         docname: props.doc || '',
         note_name: _note.value.name,
-        note: { custom_title: _note.value.custom_title, note: _note.value.note },
+        note: { custom_title: _note.value.custom_title, note: _note.value.note || '' },
       })
       if (d.name) {
         notes.value?.reload()
@@ -118,7 +118,7 @@ async function updateNote() {
         doctype: props.doctype,
         docname: props.doc || '',
         title: _note.value.custom_title,
-        note: _note.value.note,
+        note: _note.value.note || '',
       })
       if (d.name) {
         capture('note_created')


### PR DESCRIPTION
## Description

This PR fixes note key error when creating empty body notes.

## Relevant Technical Choices

- use empty string if note is empty

## Testing Instructions

- create empty notes

## Additional Information:

> N/A

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
