### PR TITLE
Remove depends_on related keys from filteredFields

### DIFF
--- a/frontend/src/components/Modals/MissingValueModal.vue
+++ b/frontend/src/components/Modals/MissingValueModal.vue
@@ -35,7 +35,8 @@
 </template>
 
 <script setup>
-import { ref, reactive, watch, computed } from 'vue'
+import { ref, reactive, watch } from 'vue'
+import Fields from '@/components/Fields.vue'
 
 const props = defineProps({
   label: {

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -1005,8 +1005,8 @@ const fieldDefinitions = computed(() => {
 const filteredFields = computed(() => {
   return fieldDefinitions.value.filter(field =>
     Object.prototype.hasOwnProperty.call(missingFields.value, field.fieldname)
-  )
-})
+  ).map(({ depends_on,display_via_depends_on, ...rest }) => rest);
+});
 
 const createProjectFromOpportunity = async () => {
   const requiredFields = Object.keys(OPPORTUNITY_TO_PROJECT_KEY_MAP);


### PR DESCRIPTION
## Description

This PR removes the `depends_on` and `display_via_depends_on` keys from `filteredFields` to ensure that the fields are rendered unconditionally, bypassing any dependency checks. These fields are essential for project creation and must always be visible.

## Relevant Technical Choices

- Remove depends_on related keys from filteredFields

## Testing Instructions

- Navigate to the Opportunity.
- Mark the opportunity as `Won`.
- Click on Create Project to open the project creation modal.
- Ensure that fields previously controlled by `depends_on` are now visible in the modal.

## Additional Information:

> N/A

## Screenshot/Screencast

[Fix depends_on.webm](https://github.com/user-attachments/assets/8efcaf42-5d27-478b-834b-2bc38530a1e4)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
