### PR TITLE
Add reports view page to crm

### DIFF
--- a/frontend/src/components/Layouts/AppSidebar.vue
+++ b/frontend/src/components/Layouts/AppSidebar.vue
@@ -92,6 +92,7 @@ import OpportunitiesIcon from '@/components/Icons/OpportunitiesIcon.vue'
 import ContactsIcon from '@/components/Icons/ContactsIcon.vue'
 import CustomersIcon from '@/components/Icons/CustomersIcon.vue'
 import ToDoIcon from '@/components/Icons/ToDoIcon.vue'
+import FileTextIcon from '@/components/Icons/FileTextIcon.vue'
 import PhoneIcon from '@/components/Icons/PhoneIcon.vue'
 import ProspectsIcon from '@/components/Icons/ProspectsIcon.vue'
 import CollapseSidebar from '@/components/Icons/CollapseSidebar.vue'
@@ -139,6 +140,11 @@ const links = [
     label: 'Customers',
     icon: CustomersIcon,
     to: 'Customers',
+  },
+  {
+    label: 'Reports',
+    icon: FileTextIcon,
+    to: 'Reports',
   },
   // {
   //   label: 'ToDos',
@@ -216,6 +222,8 @@ function getIcon(routeName, icon) {
       return NoteIcon
     case 'Call Logs':
       return PhoneIcon
+    case 'Reports':
+      return FileTextIcon
     default:
       return PinIcon
   }

--- a/frontend/src/components/ListViews/ReportsListView.vue
+++ b/frontend/src/components/ListViews/ReportsListView.vue
@@ -1,0 +1,126 @@
+<template>
+  <ListView
+    :class="$attrs.class"
+    :columns="columns"
+    :rows="rows"
+    :options="{
+      onRowClick: (row) => openReportTab(row.report_name),
+      selectable: false,
+      showTooltip: options.showTooltip,
+      resizeColumn: options.resizeColumn,
+    }"
+    row-key="name"
+  >
+    <ListHeader class="sm:mx-5 mx-3" @columnWidthUpdated="emit('columnWidthUpdated')">
+      <ListHeaderItem
+        v-for="column in columns"
+        :key="column.key"
+        :item="column"
+        @columnWidthUpdated="emit('columnWidthUpdated', column)"
+      >
+      </ListHeaderItem>
+    </ListHeader>
+    <ListRows :rows="rows" v-slot="{ idx, column, item, row }">
+      <ListRowItem :item="item">
+        <template #default="{ label }">
+          <div
+            v-if="['modified', 'creation'].includes(column.key)"
+            class="truncate text-base"
+            @click="
+              (event) =>
+                emit('applyFilter', {
+                  event,
+                  idx,
+                  column,
+                  item,
+                  firstColumn: columns[0],
+                })
+            "
+          >
+            <Tooltip :text="item.label">
+              <div>{{ item.timeAgo }}</div>
+            </Tooltip>
+          </div>
+          <div
+            v-else
+            class="truncate text-base"
+            @click="
+              (event) =>
+                emit('applyFilter', {
+                  event,
+                  idx,
+                  column,
+                  item,
+                  firstColumn: columns[0],
+                })
+            "
+          >
+            {{ label }}
+          </div>
+        </template>
+      </ListRowItem>
+    </ListRows>
+  </ListView>
+  <ListFooter
+    v-if="pageLengthCount"
+    class="border-t sm:px-5 px-3 py-2"
+    v-model="pageLengthCount"
+    :options="{
+      rowCount: options.rowCount,
+      totalCount: options.totalCount,
+    }"
+    @loadMore="emit('loadMore')"
+  />
+</template>
+
+<script setup>
+import ListRows from '@/components/ListViews/ListRows.vue'
+import { ListView, ListHeader, ListHeaderItem, ListRowItem, ListFooter, Tooltip } from 'frappe-ui'
+import { watch } from 'vue'
+
+const props = defineProps({
+  rows: {
+    type: Array,
+    required: true,
+  },
+  columns: {
+    type: Array,
+    required: true,
+  },
+  options: {
+    type: Object,
+    default: () => ({
+      selectable: false,
+      showTooltip: true,
+      resizeColumn: false,
+      totalCount: 0,
+      rowCount: 0,
+    }),
+  },
+})
+
+const emit = defineEmits([
+  'loadMore',
+  'updatePageCount',
+  'columnWidthUpdated',
+  'applyFilter',
+  'applyLikeFilter',
+  'likeDoc',
+])
+
+const pageLengthCount = defineModel()
+
+function openReportTab(reportName) {
+  const url = `${window.location.origin}/app/query-report/${encodeURIComponent(reportName.trim())}`
+  window.open(url, '_blank')
+}
+
+watch(pageLengthCount, (val, old_value) => {
+  if (val === old_value) return
+  emit('updatePageCount', val)
+})
+
+defineExpose({
+  customListActions: null,
+})
+</script>

--- a/frontend/src/pages/Reports.vue
+++ b/frontend/src/pages/Reports.vue
@@ -1,0 +1,91 @@
+<template>
+  <LayoutHeader>
+    <template #left-header>
+      <ViewBreadcrumbs v-model="viewControls" routeName="Reports" />
+    </template>
+    <template #right-header>
+      <CustomActions v-if="reportsListView?.customListActions" :actions="reportsListView.customListActions" />
+    </template>
+  </LayoutHeader>
+  <ViewControls
+    ref="viewControls"
+    v-model="reports"
+    v-model:loadMore="loadMore"
+    v-model:resizeColumn="triggerResize"
+    v-model:updatedPageCount="updatedPageCount"
+    doctype="Report"
+    :options="{
+      allowedViews: ['list'],
+    }"
+  />
+  <ReportsListView
+    ref="reportsListView"
+    v-if="reports.data && rows.length"
+    v-model="reports.data.page_length_count"
+    v-model:list="reports"
+    :rows="rows"
+    :columns="reports.data.columns"
+    :options="{
+      showTooltip: false,
+      resizeColumn: true,
+      rowCount: reports.data.row_count,
+      totalCount: reports.data.total_count,
+    }"
+    @loadMore="() => loadMore++"
+    @columnWidthUpdated="() => triggerResize++"
+    @updatePageCount="(count) => (updatedPageCount = count)"
+    @applyFilter="(data) => viewControls.applyFilter(data)"
+    @applyLikeFilter="(data) => viewControls.applyLikeFilter(data)"
+    @likeDoc="(data) => viewControls.likeDoc(data)"
+  />
+  <div v-else-if="reports.data" class="flex h-full items-center justify-center">
+    <div class="flex flex-col items-center gap-3 text-xl font-medium text-ink-gray-4">
+      <FileTextIcon class="h-10 w-10" />
+      <span>{{ __('No {0} Found', [__('Reports')]) }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import ViewBreadcrumbs from '@/components/ViewBreadcrumbs.vue'
+import CustomActions from '@/components/CustomActions.vue'
+import FileTextIcon from '@/components/Icons/FileTextIcon.vue'
+import LayoutHeader from '@/components/LayoutHeader.vue'
+import ReportsListView from '@/components/ListViews/ReportsListView.vue'
+import ViewControls from '@/components/ViewControls.vue'
+import { dateFormat, dateTooltipFormat, timeAgo } from '@/utils'
+import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
+
+const reportsListView = ref(null)
+
+// reports data is loaded in the ViewControls component
+const reports = ref({})
+const loadMore = ref(1)
+const triggerResize = ref(1)
+const updatedPageCount = ref(20)
+const viewControls = ref(null)
+
+// Rows
+const rows = computed(() => {
+  if (!reports.value?.data?.data) return []
+  return parseRows(reports.value?.data.data)
+})
+
+function parseRows(rows) {
+  return rows.map((report) => {
+    let _rows = {}
+    reports.value.data.rows.forEach((row) => {
+      _rows[row] = report[row]
+
+      if (['modified', 'creation'].includes(row)) {
+        _rows[row] = {
+          label: dateFormat(report[row], dateTooltipFormat),
+          timeAgo: __(timeAgo(report[row])),
+        }
+      }
+    })
+    return _rows
+  })
+}
+</script>

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -118,6 +118,13 @@ const routes = [
     props: true,
   },
   {
+    alias: '/reports',
+    path: '/reports/view/:viewType?',
+    name: 'Reports',
+    component: () => import('@/pages/Reports.vue'),
+    meta: { scrollPos: { top: 0, left: 0 } },
+  },
+  {
     path: '/:invalidpath',
     name: 'Invalid Page',
     component: () => import('@/pages/InvalidPage.vue'),

--- a/next_crm/api/doc.py
+++ b/next_crm/api/doc.py
@@ -282,6 +282,14 @@ def get_data(
         default_filters = frappe.parse_json(default_filters)
         filters.update(default_filters)
 
+    if doctype == "Report":
+        has_roles = frappe.get_all(
+            "Has Role",
+            filters={"role": ["in", ["Sales User", "Sales Manager"]]},
+            fields=["parent"],
+        )
+        filters["name"] = ["in", [d.get("parent") for d in has_roles]]
+
     is_default = True
     data = []
     _list = get_controller(doctype)

--- a/next_crm/api/doc.py
+++ b/next_crm/api/doc.py
@@ -290,6 +290,8 @@ def get_data(
             pluck="parent",
         )
         filters["name"] = ["in", has_roles]
+        if not filters.get("disabled"):
+            filters["disabled"] = 0
 
     is_default = True
     data = []

--- a/next_crm/api/doc.py
+++ b/next_crm/api/doc.py
@@ -287,8 +287,9 @@ def get_data(
             "Has Role",
             filters={"role": ["in", ["Sales User", "Sales Manager"]]},
             fields=["parent"],
+            pluck="parent",
         )
-        filters["name"] = ["in", [d.get("parent") for d in has_roles]]
+        filters["name"] = ["in", has_roles]
 
     is_default = True
     data = []

--- a/next_crm/hooks.py
+++ b/next_crm/hooks.py
@@ -144,6 +144,7 @@ override_doctype_class = {
     "ToDo": "next_crm.overrides.todo.ToDo",
     "Prospect": "next_crm.overrides.prospect.Prospect",
     "Address": "next_crm.overrides.address.CustomAddress",
+    "Report": "next_crm.overrides.report.OverrideReport",
 }
 
 # Document Events

--- a/next_crm/overrides/report.py
+++ b/next_crm/overrides/report.py
@@ -1,0 +1,33 @@
+from frappe.core.doctype.report.report import Report
+
+
+class OverrideReport(Report):
+
+    @staticmethod
+    def default_list_data():
+        columns = [
+            {
+                "label": "Report Name",
+                "type": "Data",
+                "key": "report_name",
+                "width": "22rem",
+            },
+            {
+                "label": "Doctype",
+                "type": "Link",
+                "key": "ref_doctype",
+                "width": "11rem",
+            },
+            {
+                "label": "Last Modified",
+                "type": "Datetime",
+                "key": "modified",
+                "width": "8rem",
+            },
+        ]
+        rows = [
+            "report_name",
+            "ref_doctype",
+            "modified",
+        ]
+        return {"columns": columns, "rows": rows}


### PR DESCRIPTION
## Description

We need a page to show all CRM related reports on the frontend.
This list view lists all reports which are for "Sales User" and or "Sales Manager" and clicking them takes to the desk view.

## Relevant Technical Choices

Created new pages for the reports list views

## Testing Instructions

- [ ] Reports page should be visible
- [ ] Clicking a report should open it in a new tab in desk view


## Screenshot/Screencast


https://github.com/user-attachments/assets/beb0e9b5-9dc2-49da-9d74-373d4ec43954




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2343