### PR TITLE
Fix project creation fields in Opportunity

### DIFF
--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -530,7 +530,7 @@ const updateOpportunityFields = async (fields, callback) => {
       fieldname: fields,
     },
     auto: true,
-    onSuccess: async () => {
+    onSuccess: async (data) => {
       opportunity.reload()
       reload.value = true
       createToast({
@@ -539,7 +539,7 @@ const updateOpportunityFields = async (fields, callback) => {
         iconClasses: 'text-ink-green-3',
       })
       callback?.()
-      await createProject(opportunity.data)
+      await createProject(data)
     },
     onError: (err) => {
       createToast({

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -919,7 +919,7 @@ const OPPORTUNITY_TO_PROJECT_KEY_MAP = {
   "territory": "custom_territory",
   "custom_project_manager": "custom_project_manager",
   "custom_complexity_level": "custom_complexity",
-  "opportunity_amount": "total_sales_amount",
+  "opportunity_amount": "estimated_costing",
   "currency": "custom_currency",
   "custom__project_size": "custom_project_size",
   "source": "custom_source",

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -390,7 +390,7 @@ const { statusOptions, getDealStatus } = statusesStore()
 const { isManager } = usersStore()
 const route = useRoute()
 const router = useRouter()
-
+const { getFields } = getMeta("Project");
 const props = defineProps({
   opportunityId: {
     type: String,
@@ -939,7 +939,6 @@ const OPPORTUNITY_TO_PROJECT_KEY_MAP = {
 
 const createProject = async (projectData) => {
   try {
-    const { getFields } = await getMeta("Project");
     const projectMeta = getFields();
     const hasCustomOpportunity = projectMeta?.some(item => item.fieldname === 'custom_opportunity');
     const projectPayload = {

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -384,10 +384,11 @@ import { ref, computed, h, onMounted, onBeforeUnmount, watch, reactive } from 'v
 import { useRoute, useRouter } from 'vue-router'
 import { useActiveTabManager } from '@/composables/useActiveTabManager'
 import { getMeta } from '@/stores/meta'
+import { replaceMeWithUser } from '../utils'
 
 const { $dialog, $socket, makeCall } = globalStore()
 const { statusOptions, getDealStatus } = statusesStore()
-const { isManager } = usersStore()
+const { isManager, getUser } = usersStore()
 const route = useRoute()
 const router = useRouter()
 const { getFields } = getMeta("Project");
@@ -522,12 +523,14 @@ const updateOpportunityFields = async (fields, callback) => {
   for (const [fieldname, value] of Object.entries(fields)) {
     if (validateRequired(fieldname, value)) return
   }
+  // The replaceMeWithUser utility replaces the value of any key containing @me with the currently logged-in user.
+  const meParsedFields = replaceMeWithUser(fields,getUser().email)
   createResource({
     url: 'frappe.client.set_value',
     params: {
       doctype: 'Opportunity',
       name: props.opportunityId,
-      fieldname: fields,
+      fieldname: meParsedFields,
     },
     auto: true,
     onSuccess: async (data) => {

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -327,3 +327,5 @@ export const debounce = (fn, delay) => {
 export const sanitizeCurrency = (str) => {
   return str.replace(/[^\d.-]/g, '');
 }
+
+export const replaceMeWithUser = (obj, user) => ({ ...obj, ...Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, v === "@me" ? user : v])) });


### PR DESCRIPTION
## Description

This PR includes the following fixes:
- Resolves the issue of project and opportunity becoming `unsynced` due to an `undefined` custom_opportunity field.
- Replaces the use of `total_sales_amount` with `estimated_costing`.
- Fixes the `@me` option not working correctly in the project_manager field within the Missing Values modal.


## Relevant Technical Choices

- Use success response data instead of static opportunity data
- Fix undefined getFields function
- Replace totals sales amount field to estimated costing
- Fix @me user not found issue

## Testing Instructions

- Go to opportunity
- Mark the opportunity as won
- A project creation modal will popup
- Click on create project
- Add Required fields
- Project should be created with the same values as of linked opportunity

## Additional Information:

> [!NOTE]
> This PR is required to sync opportunity and product updates: https://github.com/rtCamp/erp-rtcamp/pull/2348

## Screenshot/Screencast

> N/A


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
