### PR TITLE
feat: Add Google Calendar sync functionality to ToDo items

### DIFF
--- a/next_crm/doc_events/todo.py
+++ b/next_crm/doc_events/todo.py
@@ -52,3 +52,13 @@ def on_update(doc, method=None):
         and doc.allocated_to
     ):
         notify_assigned_user(doc, is_cancelled=True)
+
+
+def on_trash(doc, method=None):
+    if doc.custom_linked_event:
+        frappe.delete_doc(
+            "Event",
+            doc.custom_linked_event,
+            ignore_permissions=True,
+            force=True,
+        )

--- a/next_crm/hooks.py
+++ b/next_crm/hooks.py
@@ -158,6 +158,7 @@ doc_events = {
         "after_insert": ["next_crm.doc_events.todo.after_insert"],
         "on_update": ["next_crm.doc_events.todo.on_update"],
         "before_insert": ["next_crm.doc_events.todo.before_insert"],
+        "on_trash": ["next_crm.doc_events.todo.on_trash"],
     },
     "Comment": {
         "on_update": ["next_crm.doc_events.comment.on_update"],


### PR DESCRIPTION
## Description

- This PR adds the following fields to the create ToDo model in next-crm:
     - **Sync with Google Calendar**: Checkbox
     - **Google Calendar**: Link
     - **Participants**: Multi Value Input
- Allows ToDos to be synced with Google Calendar as a Event.
- If latest [Frappe Appointment](https://github.com/rtCamp/frappe-appointment) is installed, the created event will be a free event (to ensure it doesn't block the calendar).

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

See: https://github.com/rtCamp/frappe-appointment/pull/232

## Screenshot/Screencast

<img width="590" alt="image" src="https://github.com/user-attachments/assets/b537ec39-75a0-4c12-b7e2-21f574e20681" />

<img width="449" alt="image" src="https://github.com/user-attachments/assets/d5f8724f-5d0a-4e74-92f5-268296abe0bb" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2313