### PR TITLE
clear crm notification through log settings

### DIFF
--- a/next_crm/ncrm/doctype/crm_notification/crm_notification.py
+++ b/next_crm/ncrm/doctype/crm_notification/crm_notification.py
@@ -9,6 +9,16 @@ class CRMNotification(Document):
     def on_update(self):
         frappe.publish_realtime("crm_notification")
 
+    @staticmethod
+    def clear_old_logs(days=15):
+        from frappe.query_builder import Interval
+        from frappe.query_builder.functions import Now
+
+        table = frappe.qb.DocType("CRM Notification")
+        frappe.db.delete(
+            table, filters={"modified": ("<", (Now() - Interval(days=days))), "read": 1}
+        )
+
 
 def notify_user(args):
     """


### PR DESCRIPTION
## Description

Currently, CRM Notifications does not get cleared automatically through log settings.
This PR adds the required function to the CRM Notifications doc to allow it's discovery in the log settings and allow auto deletion of unread notifications.

## Relevant Technical Choices

Added method for auto deletion which defaults to 15 days.

## Testing Instructions

- [ ] CRM Notification should be addable through the "Log Settings" doc

## Screenshot
![image](https://github.com/user-attachments/assets/703ceb7b-7080-421d-b0d6-de56bed9b14a)

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)