### PR TITLE
don't allow setting same status again in opportunity

### DIFF
--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -905,11 +905,9 @@ function triggerCall() {
 function updateField(name, value, callback) {
   const isStatusField = name === "status";
 
-  if (opportunity.data[name] === value && value != "Won") {
+  if (isStatusField && opportunity.data[name] === value && value != "Won") {
     return;
-  }
-
-  if (isStatusField && value === "Lost") {
+  } else if (isStatusField && value === "Lost") {
     showLostReasonModal.value = true;
     return;
   }
@@ -919,7 +917,7 @@ function updateField(name, value, callback) {
     callback?.();
   });
 
-  if (value === "Won") {
+  if (isStatusField && value === "Won") {
     showCreateProjectModal.value = true;
   }
 }

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -513,9 +513,6 @@ function updateOpportunity(fieldname, value, callback) {
         iconClasses: 'text-ink-green-3',
       })
       callback?.()
-      if (data.status === "Won") {
-        showCreateProjectModal.value = true;
-      }
     },
     onError: (err) => {
       createToast({
@@ -908,6 +905,10 @@ function triggerCall() {
 function updateField(name, value, callback) {
   const isStatusField = name === "status";
 
+  if (opportunity.data[name] === value && value != "Won") {
+    return;
+  }
+
   if (isStatusField && value === "Lost") {
     showLostReasonModal.value = true;
     return;
@@ -917,6 +918,10 @@ function updateField(name, value, callback) {
     opportunity.data[name] = value;
     callback?.();
   });
+
+  if (value === "Won") {
+    showCreateProjectModal.value = true;
+  }
 }
 
 const projectResource = createResource({


### PR DESCRIPTION
## Description

Currently even if we don't change status but click on the current one again it still triggers the save flow.
This causes issues with status like won and lost which triggers modals to re-appear.
Also, if a project is set as won then changing any field also triggers the create project modal.

## Relevant Technical Choices

Updated the change function to return if same status is set again and moved logic of won dialog to correct function.

## Testing Instructions

- [ ] Try to set same status twice in opportunity

## Additional Information:

The logic is avoided for won status to allow creation of project at a later date by again clicking on won, but the trigger on setting any other field is fixed.

## Screenshot/Screencast


https://github.com/user-attachments/assets/01ee9d12-4b0b-454e-9442-6b2edc58362b




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)