### PR TITLE
Make note scrollable

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -177,6 +177,7 @@ declare module 'vue' {
     RenameModal: typeof import('./src/components/Modals/RenameModal.vue')['default']
     ReplyAllIcon: typeof import('./src/components/Icons/ReplyAllIcon.vue')['default']
     ReplyIcon: typeof import('./src/components/Icons/ReplyIcon.vue')['default']
+    ReportsListView: typeof import('./src/components/ListViews/ReportsListView.vue')['default']
     Resizer: typeof import('./src/components/Resizer.vue')['default']
     RightSideLayoutIcon: typeof import('./src/components/Icons/RightSideLayoutIcon.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']

--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -51,7 +51,7 @@
         :content="note.note"
         :editable="false"
         editor-class="!prose-sm max-w-none !text-sm text-ink-gray-5 focus:outline-none"
-        class="flex-1 overflow-hidden"
+        class="flex-1 overflow-x-hidden"
       />
     </div>
     <div v-if="note.noteReplies?.length" class="ml-6 mt-2 space-y-3 border-l border-gray-200 pl-4">

--- a/frontend/src/components/CommunicationArea.vue
+++ b/frontend/src/components/CommunicationArea.vue
@@ -101,6 +101,7 @@
         variant: 'solid',
         onClick: submitNote,
         disabled: noteEmpty,
+        loading: submittingNoteReply,
       }"
       :discardButtonProps="{
         onClick: () => {
@@ -308,6 +309,7 @@ const newNoteTitle = ref('')
 const newNoteContent = ref('')
 const newNoteEditor = ref(null)
 const noteParent = ref('')
+const submittingNoteReply = ref(false)
 
 const noteEmpty = computed(() => {
   return !newNoteTitle.value && (!newNoteContent.value || newNoteContent.value === '<p></p>')
@@ -321,7 +323,7 @@ function toggleNoteBox() {
 
 async function submitNote() {
   if (noteEmpty.value) return
-
+  submittingNoteReply.value = true
   await call('next_crm.api.crm_note.create_note', {
     doctype: props.doctype,
     docname: doc.value.data.name || '',
@@ -330,7 +332,7 @@ async function submitNote() {
     parent_note: noteParent.value,
   })
   showNoteBox.value = false
-
+  submittingNoteReply.value = false
   newNoteTitle.value = ''
   newNoteContent.value = ''
   reload.value = true


### PR DESCRIPTION
## Description

This PR makes the `NoteArea` scrollable and adds a loading state to enhance the user experience when adding note replies.

## Relevant Technical Choices

- Replace `overflow-hidden` to `overflow-x-hidden` tw class for vertical scrollbar.
- Add `submittingNoteReply` ref to control loading state when adding a Note Reply.

## Testing Instructions

- Add lengthy note , it should be scrollable.
- Try adding a Note reply to see the loading spinner in communication area.

## Additional Information:

> N/A

## Screenshot/Screencast

[Scrollable note.webm](https://github.com/user-attachments/assets/aaf682eb-852b-4a6e-b983-a199d7c58d17)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes https://github.com/rtCamp/erp-rtcamp/issues/2355