### PR TITLE
Add datetime local input in to and from time in todo

### DIFF
--- a/frontend/src/components/Modals/ToDoModal.vue
+++ b/frontend/src/components/Modals/ToDoModal.vue
@@ -91,19 +91,25 @@
             :placeholder="__('01/04/2024')"
             input-class="border-none"
           />
-          <DateTimePicker
+          <TextInput
             v-if="fromTime"
-            class="datepicker w-36"
-            v-model="_todo.custom_from_time"
+            type="datetime-local"
+            :ref_for="true"
+            size="sm"
+            variant="subtle"
             :placeholder="__('From Time')"
-            input-class="border-none"
+            v-model="_todo.custom_from_time"
+            class="datepicker w-fit border-none"
           />
-          <DateTimePicker
+          <TextInput
             v-if="toTime"
-            class="datepicker w-36"
-            v-model="_todo.custom_to_time"
+            type="datetime-local"
+            :ref_for="true"
+            size="sm"
+            variant="subtle"
             :placeholder="__('To Time')"
-            input-class="border-none"
+            v-model="_todo.custom_to_time"
+            class="datepicker w-fit border-none"
           />
           <Dropdown :options="todoPriorityOptions(updateToDoPriority)">
             <Button :label="_todo.priority" class="w-full justify-between">
@@ -166,7 +172,7 @@ import MultiValueInput from '../Controls/MultiValueInput.vue'
 import { todoStatusOptions, todoPriorityOptions } from '@/utils'
 import { usersStore } from '@/stores/users'
 import { capture } from '@/telemetry'
-import { TextEditor, Dropdown, Tooltip, call, DatePicker, DateTimePicker } from 'frappe-ui'
+import { TextEditor, Dropdown, Tooltip, call, DatePicker, TextInput } from 'frappe-ui'
 import { ref, watch, nextTick, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { getMeta } from '@/stores/meta'


### PR DESCRIPTION
## Description

ThiS PR replaces `DateTimePicker` to `TextInput` `[type="datetime-local"]` for better usability in ToDo From and To Time fields

## Relevant Technical Choices

- Replace `DateTimePicker` to `TextInput` `[type="datetime-local"]`

## Testing Instructions

- Open NCRM
- Create/Edit Form and To Time ToDo in Lead or opportunity

## Additional Information:

> N/A

## Screenshot/Screencast

[ToDo FromTo.webm](https://github.com/user-attachments/assets/85cccb2a-0ce2-47a3-bee6-b7ff4b9c6e6d)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)