### PR TITLE
Only show CRM notifications in frontend

### DIFF
--- a/frontend/src/components/Notifications.vue
+++ b/frontend/src/components/Notifications.vue
@@ -11,9 +11,7 @@
     }"
   >
     <div class="flex h-screen flex-col text-ink-gray-9">
-      <div
-        class="z-20 flex items-center justify-between border-b bg-surface-white px-5 py-2.5"
-      >
+      <div class="z-20 flex items-center justify-between border-b bg-surface-white px-5 py-2.5">
         <div class="text-base font-medium">{{ __('Notifications') }}</div>
         <div class="flex gap-1">
           <Tooltip :text="__('Mark all as read')">
@@ -36,10 +34,7 @@
           </Tooltip>
         </div>
       </div>
-      <div
-        v-if="notifications.data?.length"
-        class="divide-y divide-outline-gray-modals overflow-auto text-base"
-      >
+      <div v-if="notifications.data?.length" class="divide-y divide-outline-gray-modals overflow-auto text-base">
         <RouterLink
           v-for="n in notifications.data"
           :key="n.comment"
@@ -48,10 +43,7 @@
           @click="markAsRead(n.comment || n.notification_type_doc)"
         >
           <div class="mt-1 flex items-center gap-2.5">
-            <div
-              class="size-[5px] rounded-full"
-              :class="[n.read ? 'bg-transparent' : 'bg-surface-gray-7']"
-            />
+            <div class="size-[5px] rounded-full" :class="[n.read ? 'bg-transparent' : 'bg-surface-gray-7']" />
             <WhatsAppIcon v-if="n.type == 'WhatsApp'" class="size-7" />
             <UserAvatar v-else :user="n.from_user.name" size="lg" />
           </div>
@@ -74,10 +66,7 @@
           </div>
         </RouterLink>
       </div>
-      <div
-        v-else
-        class="flex flex-1 flex-col items-center justify-center gap-2"
-      >
+      <div v-else class="flex flex-1 flex-col items-center justify-center gap-2">
         <NotificationsIcon class="h-20 w-20 text-ink-gray-2" />
         <div class="text-lg font-medium text-ink-gray-4">
           {{ __('No new notifications') }}
@@ -91,11 +80,7 @@ import WhatsAppIcon from '@/components/Icons/WhatsAppIcon.vue'
 import MarkAsDoneIcon from '@/components/Icons/MarkAsDoneIcon.vue'
 import NotificationsIcon from '@/components/Icons/NotificationsIcon.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
-import {
-  visible,
-  notifications,
-  notificationsStore,
-} from '@/stores/notifications'
+import { visible, notifications, notificationsStore } from '@/stores/notifications'
 import { globalStore } from '@/stores/global'
 import { timeAgo } from '@/utils'
 import { onClickOutside } from '@vueuse/core'
@@ -138,17 +123,26 @@ onMounted(() => {
 })
 
 function getRoute(notification) {
-  let params = {
-    leadId: notification.reference_name,
-  }
-  if (notification.route_name === 'Opportunity') {
+  const permittedDoctypes = ['Lead', 'Opportunity']
+
+  let params
+  if (notification.route_name === 'Lead') {
+    params = {
+      leadId: notification.reference_name,
+    }
+  } else if (notification.route_name === 'Opportunity') {
     params = {
       opportunityId: notification.reference_name,
+    }
+  } else {
+    params = {
+      doc: notification.reference_doctype.trim().replaceAll(' ', '-').toLowerCase(),
+      docname: notification.reference_name,
     }
   }
 
   return {
-    name: notification.route_name,
+    name: permittedDoctypes.includes(notification.reference_doctype) ? notification.route_name : 'App',
     params: params,
     hash: notification.hash,
   }

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -125,6 +125,15 @@ const routes = [
     meta: { scrollPos: { top: 0, left: 0 } },
   },
   {
+    alias: '/app',
+    path: '/app/:doc/:docname',
+    name: 'App',
+    redirect: (route) => {
+      window.location.href = window.location.origin + route.fullPath
+      return '/'
+    }
+  },
+  {
     path: '/:invalidpath',
     name: 'Invalid Page',
     component: () => import('@/pages/InvalidPage.vue'),

--- a/next_crm/api/notifications.py
+++ b/next_crm/api/notifications.py
@@ -31,17 +31,9 @@ def get_notifications():
                 "notification_text": notification.notification_text,
                 "notification_type_doctype": notification.notification_type_doctype,
                 "notification_type_doc": notification.notification_type_doc,
-                "reference_doctype": (
-                    "opportunity"
-                    if notification.reference_doctype == "Opportunity"
-                    else "lead"
-                ),
+                "reference_doctype": notification.reference_doctype,
                 "reference_name": notification.reference_name,
-                "route_name": (
-                    "Opportunity"
-                    if notification.reference_doctype == "Opportunity"
-                    else "Lead"
-                ),
+                "route_name": notification.reference_doctype,
             }
         )
 

--- a/next_crm/doc_events/comment.py
+++ b/next_crm/doc_events/comment.py
@@ -1,15 +1,13 @@
+import frappe
+
 from next_crm.api.comment import notify_mentions
 
 
 def on_update(doc, method=None):
-    allowed_doctypes = [
-        "ToDo",
-        "Opportunity",
-        "Lead",
-        "Prospect",
-        "Customer",
-        "Address",
-        "Contact",
-    ]
-    if doc.reference_doctype in allowed_doctypes:
+    module = frappe.get_meta(doc.reference_doctype).module
+    if (
+        module == "NCRM"
+        or module == "CRM"
+        or doc.reference_doctype in ["Address", "Contact"]
+    ):
         notify_mentions(doc)


### PR DESCRIPTION
## Description

Currently notifications from all mentioned comments show up in Next CRM.
And, these notifications fail due to logic specific to Lead and Opportunity.

This PR fixes that by changing how notifications are triggered and restricts them to certain doctypes

## Relevant Technical Choices

Only NCRM and CRM doctype notifications will appear, except for "Address" and "Contacts", which are displayed in CRM but are part of the "Contacts" module. Hence, they are checked through a list.

Clicking any notification except for lead or opportunity will take you to the backend.

## Testing Instructions

- [ ] Tag a CRM user on multiple docs
- [ ] Only NCRM related notifications should show
- [ ] Clicking them should redirect to bthe ackend wherever required


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2366