### PR TITLE
add link filter to opportunity from

### DIFF
--- a/next_crm/fixtures/property_setter.json
+++ b/next_crm/fixtures/property_setter.json
@@ -478,5 +478,21 @@
     "property_type": "JSON",
     "row_name": null,
     "value": "[[\"User\",\"user_type\",\"=\",\"System User\"],[\"User\",\"role\",\"in\",[\"Sales User\",\"Sales Manager\"]]]"
+  },
+  {
+    "default_value": null,
+    "doc_type": "Opportunity",
+    "docstatus": 0,
+    "doctype": "Property Setter",
+    "doctype_or_field": "DocField",
+    "field_name": "opportunity_from",
+    "is_system_generated": 0,
+    "modified": "2025-06-23 14:07:10.062071",
+    "module": "NCRM",
+    "name": "Opportunity-opportunity_from-link_filters",
+    "property": "link_filters",
+    "property_type": "JSON",
+    "row_name": null,
+    "value": "[[\"DocType\", \"name\", \"in\", [\"Customer\", \"Lead\", \"Prospect\"]]]"
   }
 ]


### PR DESCRIPTION
## Description

Currently fields other than "Customer, Lead, Prospect" appears in opportunity from field due to lack of filters.

This causes all doctypes to show once filters set for the quick filters are emptied from cache.

This PR fixes that by adding relevant link filters in property setter

## Relevant Technical Choices

Added Link filters through property setter to `opportunity_from` field.

## Testing Instructions

- [ ] Open any opportunity
- [ ] Attempt to type different doctype names in `opportunity from` field
- [ ] Only Customer, Lead, Prospect should appear there


## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/11dc1576-a892-4910-8427-dfa2f79e9618)

![image](https://github.com/user-attachments/assets/e69ba445-48b9-4b64-8850-a0552e427af7)

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)