### PR TITLE
Replace DateTimePicker to date-time-locale for Event from and to time

### DIFF
--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -158,7 +158,7 @@ import MultiValueInput from '../Controls/MultiValueInput.vue'
 import { eventStatusOptions, createToast } from '@/utils'
 import { usersStore } from '@/stores/users'
 import { capture } from '@/telemetry'
-import { TextEditor, Dropdown, FormControl, Tooltip, call, createResource } from 'frappe-ui'
+import { TextEditor, Dropdown, FormControl, Tooltip, call, TextInput, createResource } from 'frappe-ui'
 import { ref, watch, nextTick, onMounted } from 'vue'
 
 function validate(value) {

--- a/frontend/src/components/Modals/EventModal.vue
+++ b/frontend/src/components/Modals/EventModal.vue
@@ -88,17 +88,23 @@
           />
         </div>
         <div class="flex flex-wrap items-center gap-2">
-          <DateTimePicker
-            class="datepicker w-36"
-            v-model="_event.starts_on"
+          <TextInput
+            type="datetime-local"
+            :ref_for="true"
+            size="sm"
+            variant="subtle"
             :placeholder="__('01/04/2024')"
-            input-class="border-none"
+            v-model="_event.starts_on"
+            class="datepicker border-none"
           />
-          <DateTimePicker
-            class="datepicker w-36"
+          <TextInput
+            type="datetime-local"
+            :ref_for="true"
+            size="sm"
+            variant="subtle"
             v-model="_event.ends_on"
             :placeholder="__('01/04/2024')"
-            input-class="border-none"
+            class="datepicker border-none"
           />
         </div>
         <div class="flex flex-wrap items-center gap-2">
@@ -152,7 +158,7 @@ import MultiValueInput from '../Controls/MultiValueInput.vue'
 import { eventStatusOptions, createToast } from '@/utils'
 import { usersStore } from '@/stores/users'
 import { capture } from '@/telemetry'
-import { TextEditor, Dropdown, FormControl, Tooltip, call, DateTimePicker, createResource } from 'frappe-ui'
+import { TextEditor, Dropdown, FormControl, Tooltip, call, createResource } from 'frappe-ui'
 import { ref, watch, nextTick, onMounted } from 'vue'
 
 function validate(value) {


### PR DESCRIPTION
## Description

This PR replaces DateTimePicker to date-time-locale for `Event` modal from and to time fields for better usability.

## Relevant Technical Choices

- Replace DateTimePicker to date-time-locale `TextInput`

## Testing Instructions

- Go to NCRM
- Open Lead/Opportunity
- Add / Update Event

## Additional Information:

> N/A

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/bce9349e-19b4-4aae-9399-d0df8925f42f)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)