### PR TITLE
update email notifications for CRM Notes

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -23,7 +23,7 @@ jobs:
       - name: fix tar dependency in alpine container image
         run: |
           apk --no-cache add tar nodejs npm python3 git bash py3-pip
-          apk --no-cache add prettier --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing
+          npm install -g prettier
           # check python modules installed versions
           python3 -m pip freeze --local
           pip install pre-commit --break-system-packages


### PR DESCRIPTION
## Description

Currently email notifications for notes says "comments" instead of "note" due to repurposed desk API.
This PR changes the function to change the email text and subject line for CRM Notes

## Relevant Technical Choices

Imported functions and code from the desk function for the notifications

## Testing Instructions

- [ ] Mention a user in note
- [ ] Check that it triggers the correct format of email

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/b65eed3e-ac9e-4a97-ab9e-8ee57b30f99d)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes https://github.com/rtCamp/erp-rtcamp/issues/2376