### PR TITLE
copy notes and threads from lead to opportunity

### DIFF
--- a/next_crm/api/crm_note.py
+++ b/next_crm/api/crm_note.py
@@ -157,11 +157,6 @@ def copy_crm_notes_to_opportunity(lead, opportunity):
         order_by="creation asc",
     )
 
-    frappe.log_error(
-        f"Migrating CRM Notes from Lead {lead} to Opportunity {opportunity}",
-        f"{notes}",
-    )
-
     for note in notes:
         new_parent_note = frappe.new_doc("CRM Note")
         new_parent_note.custom_title = note.custom_title or ""

--- a/next_crm/api/crm_note.py
+++ b/next_crm/api/crm_note.py
@@ -34,6 +34,10 @@ def create_note(doctype, docname, title=None, note=None, parent_note=None):
 
     new_note.insert()
     notify_mentions_ncrm(note, new_note.name, docname, doctype)
+    # Doctype are fetched using 'get_cached_doc'. hence we need to clear the cache
+    # to ensure the new note is reflected in the doc's child table. Without this,
+    # the notes sometimes gets deleted when lead is saved during conversion.
+    frappe.clear_document_cache(doctype, docname)
     return new_note
 
 
@@ -66,9 +70,9 @@ def notify_mentions_ncrm(note, note_name, docname, doctype):
         name = title or docname or None
         notification_text = f"""
         <div class="mb-2 leading-5 text-ink-gray-5">
-            <span class="font-medium text-ink-gray-9">{ owner}</span>
-            <span>{ _('mentioned you in a Note in {0}').format(doctype) }</span>
-            <span class="font-medium text-ink-gray-9">{ name }</span>
+            <span class="font-medium text-ink-gray-9">{owner}</span>
+            <span>{_("mentioned you in a Note in {0}").format(doctype)}</span>
+            <span class="font-medium text-ink-gray-9">{name}</span>
         </div>
         """
         notify_user(
@@ -139,3 +143,69 @@ def delete_note(note_name):
     frappe.db.delete("CRM Notification", {"notification_type_doc": note_name})
     note.delete()
     return True
+
+
+def copy_crm_notes_to_opportunity(lead, opportunity):
+    notes = frappe.get_all(
+        "CRM Note",
+        fields="*",
+        filters={
+            "parent": lead,
+            "parenttype": "Lead",
+            "custom_parent_note": ["in", ["", None]],
+        },
+        order_by="creation asc",
+    )
+
+    frappe.log_error(
+        f"Migrating CRM Notes from Lead {lead} to Opportunity {opportunity}",
+        f"{notes}",
+    )
+
+    for note in notes:
+        new_parent_note = frappe.new_doc("CRM Note")
+        new_parent_note.custom_title = note.custom_title or ""
+        new_parent_note.note = note.note or ""
+        new_parent_note.parenttype = "Opportunity"
+        new_parent_note.parent = opportunity
+        new_parent_note.parentfield = "notes"
+        new_parent_note.added_by = note.added_by
+        new_parent_note.added_on = note.added_on or now()
+
+        new_parent_note.insert(ignore_permissions=True)
+
+        frappe.db.set_value(
+            "CRM Note",
+            new_parent_note.name,
+            {
+                "owner": note.owner,
+            },
+        )
+
+        child_notes = frappe.get_all(
+            "CRM Note",
+            filters={"custom_parent_note": note.name},
+            fields="*",
+        )
+
+        for child_note in child_notes:
+            new_child_note = frappe.new_doc("CRM Note")
+            new_child_note.custom_title = child_note.custom_title or ""
+            new_child_note.note = child_note.note or ""
+            new_child_note.parenttype = "Opportunity"
+            new_child_note.parent = opportunity
+            new_child_note.parentfield = "notes"
+            new_child_note.added_by = child_note.added_by
+            new_child_note.added_on = child_note.added_on or now()
+            new_child_note.custom_parent_note = new_parent_note.name
+
+            new_child_note.insert(ignore_permissions=True)
+
+            frappe.db.set_value(
+                "CRM Note",
+                new_child_note.name,
+                {
+                    "owner": child_note.owner,
+                },
+            )
+    frappe.db.commit()

--- a/next_crm/overrides/lead.py
+++ b/next_crm/overrides/lead.py
@@ -378,6 +378,15 @@ def convert_to_opportunity(lead, prospect, existing_contact=None, doc=None):
     else:
         customer_or_prospect = lead.create_prospect()
     opportunity = lead.create_opportunity(contact, customer_or_prospect)
+
+    frappe.enqueue(
+        "next_crm.api.crm_note.copy_crm_notes_to_opportunity",
+        job_name=f"Copy CRM Notes from {lead} to {opportunity}",
+        queue="short",
+        enqueue_after_commit=True,
+        lead=lead.name,
+        opportunity=opportunity,
+    )
     return opportunity
 
 


### PR DESCRIPTION
## Description

Currently notes don't copy the threaded structure when a lead converts to opportunity.
This is due to the change in names of notes that happens during creation of opportunity.

The child note appears as a parent note due to the parent pointing to wrong link name.

## Relevant Technical Choices

Added a queue job to migrate all notes with correct structure (new parent names) to the opportunity on conversion.

It also monkey patches the core code to prevent notes default copy on conversion. 

## Testing Instructions

- [ ] Create a lead
- [ ] Create multiple notes and comments
- [ ] Attempt to convert lead to opportunity

## Screenshot/Screencast

![image](https://github.com/user-attachments/assets/8342ab74-ea98-4158-8747-1e8d56c8663c)


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)