### PR TITLE
add button to clear notifications

### DIFF
--- a/frontend/src/components/Notifications.vue
+++ b/frontend/src/components/Notifications.vue
@@ -23,6 +23,15 @@
               </Button>
             </div>
           </Tooltip>
+          <Tooltip :text="__('Clear all notifications')">
+            <div>
+              <Button variant="ghost" @click="() => clearAll()">
+                <template #icon>
+                  <FeatherIcon name="trash-2" class="h-4 w-4" />
+                </template>
+              </Button>
+            </div>
+          </Tooltip>
           <Tooltip :text="__('Close')">
             <div>
               <Button variant="ghost" @click="() => toggle()">
@@ -82,10 +91,10 @@ import NotificationsIcon from '@/components/Icons/NotificationsIcon.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import { visible, notifications, notificationsStore } from '@/stores/notifications'
 import { globalStore } from '@/stores/global'
-import { timeAgo } from '@/utils'
+import { timeAgo, createToast } from '@/utils'
 import { onClickOutside } from '@vueuse/core'
 import { capture } from '@/telemetry'
-import { Tooltip } from 'frappe-ui'
+import { Tooltip, call } from 'frappe-ui'
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 
 const { $socket } = globalStore()
@@ -110,6 +119,16 @@ function markAsRead(doc) {
 function markAllAsRead() {
   capture('notification_mark_all_as_read')
   mark_as_read.reload()
+}
+
+async function clearAll() {
+  await call('next_crm.api.notifications.clear_all_notifications')
+  createToast({
+    title: __('Notifications deleted successfully'),
+    icon: 'check',
+    iconClasses: 'text-green-500',
+  })
+  notifications.reload()
 }
 
 onBeforeUnmount(() => {

--- a/next_crm/api/notifications.py
+++ b/next_crm/api/notifications.py
@@ -81,4 +81,3 @@ def clear_all_notifications():
     """
     user = frappe.session.user
     frappe.db.delete("CRM Notification", {"to_user": user})
-    return

--- a/next_crm/api/notifications.py
+++ b/next_crm/api/notifications.py
@@ -72,3 +72,13 @@ def get_hash(notification):
         if "has been removed by" in notification.message:
             _hash = ""
     return _hash
+
+
+@frappe.whitelist()
+def clear_all_notifications():
+    """
+    Clear all notifications for the current user.
+    """
+    user = frappe.session.user
+    frappe.db.delete("CRM Notification", {"to_user": user})
+    return


### PR DESCRIPTION
## Description

This PR adds a button to clear all notifications assigned to a user

## Relevant Technical Choices

Added an API function to clear all notifications

## Testing Instructions

- [ ] Open the notification panel and click the clear all button
- [ ] All notifications of that user should get deleted

## Screenshot/Screencast


https://github.com/user-attachments/assets/3362539d-1511-4cfe-9304-0cd6d8fc7bf6




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2400