### PR TITLE
Fix attachment for parent note in Activity

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -484,7 +484,7 @@ const activities = computed(() => {
       name: note.name,
       type: 'note',
       value: 'added a note',
-      attachments: [],
+      attachments: note.attachments || [],
     }))
 
     _activities = [..._activities, ...notesAsActivities]

--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -73,7 +73,7 @@ import { usersStore } from '@/stores/users'
 import ReplyIcon from '@/components/Icons/ReplyIcon.vue'
 import { createToast } from '@/utils'
 import NoteAttachments from './NoteAttachments.vue'
-import { ref, watch } from 'vue'
+import { ref, watch, onMounted } from 'vue'
 
 const props = defineProps({
   note: Object,
@@ -91,18 +91,21 @@ function replyNote() {
 }
 
 const filteredAttachments = ref([])
-watch(
-  [() => notes?.value?.data?.attachments, props.note],
-  ([attachments, note]) => {
-    const fileNames = note?.attachments.map((item) => item.filename)
-    if (!attachments || !fileNames?.length) {
-      filteredAttachments.value = []
-      return
-    }
-    filteredAttachments.value = attachments.filter((att) => fileNames.includes(att.name))
-  },
-  { immediate: true },
-)
+
+onMounted(() => {
+  watch(
+    [() => notes?.value?.data?.attachments, () => props.note],
+    ([attachments, note]) => {
+      const fileNames = note?.attachments?.map((item) => item.filename) || []
+      if (!attachments || fileNames.length === 0) {
+        filteredAttachments.value = []
+        return
+      }
+      filteredAttachments.value = attachments.filter((att) => fileNames.includes(att.name))
+    },
+    { immediate: true },
+  )
+})
 
 async function deleteNote(name) {
   try {

--- a/frontend/src/components/Activities/NoteArea.vue
+++ b/frontend/src/components/Activities/NoteArea.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="activity group">
+  <div class="activity group overflow-hidden">
     <div class="mb-1 flex items-center justify-stretch gap-2 py-1 text-base">
       <div class="inline-flex items-center flex-wrap gap-1 text-ink-gray-5">
         <UserAvatar class="mr-1" :user="note.owner" size="md" />

--- a/frontend/src/components/NoteEditor.vue
+++ b/frontend/src/components/NoteEditor.vue
@@ -9,7 +9,7 @@
       />
       <TextEditor
         ref="textEditor"
-        :editor-class="['prose-sm max-w-none', editable && 'min-h-[7rem]']"
+        :editor-class="['prose-sm max-w-none', editable && 'min-h-[4rem]']"
         :content="content"
         @change="editable ? (content = $event) : null"
         :starterkit-options="{ heading: { levels: [2, 3, 4, 5, 6] } }"


### PR DESCRIPTION
## Description

This PR fixes NoteAttachment to be rendered for parent Note in Activity tab

## Relevant Technical Choices

- Update `filteredAttachments`  value on mounting of the component

## Testing Instructions

- Go to NCRM
- Open any Lead/Opportunity
- Create a Note with attachment(s) , then add a note reply with attachments
- Go to activity tab
- Parent Note should have attachments visible

## Additional Information:

> N/A

## Screenshot/Screencast

Before:
<img width="1343" height="923" alt="image" src="https://github.com/user-attachments/assets/6a96ef04-563f-4e6a-a7eb-6d05415bce93" />


After:
<img width="1335" height="882" alt="image" src="https://github.com/user-attachments/assets/46eae748-a014-4cfa-81b5-efd823fe08d6" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
