### PR TITLE
Change google_calendar when updating assignee in ToDo

### DIFF
--- a/frontend/src/components/Modals/ToDoModal.vue
+++ b/frontend/src/components/Modals/ToDoModal.vue
@@ -65,7 +65,7 @@
             class="form-control"
             :value="getUser(_todo.allocated_to).full_name"
             doctype="User"
-            @change="(option) => (_todo.allocated_to = option)"
+            @change="(option) => updateAssignee(option)"
             :placeholder="__('John Doe')"
             :hideMe="true"
             :filters="[['User', 'user_type', '=', 'System User']]"
@@ -232,6 +232,20 @@ function updateToDoStatus(status) {
 
 function updateToDoPriority(priority) {
   _todo.value.priority = priority
+}
+
+function updateAssignee(option) {
+  _todo.value.allocated_to = option
+
+  const assigneeUser = getUser(option)
+
+  if (assigneeUser.google_calendar) {
+    _event.value.google_calendar = assigneeUser.google_calendar
+    _event.value.sync_with_google_calendar = 1
+  } else {
+    _event.value.google_calendar = null
+    _event.value.sync_with_google_calendar = 0
+  }
 }
 
 function redirect() {


### PR DESCRIPTION
## Description

This PR syncs Google Calendar based on the assignee selected in the ToDo modal.

## Relevant Technical Choices

- Create utility fx `updateAssignee` that update `google_calendar` when updating assignee in ToDo

## Testing Instructions

- Go to NCRM
- Open a Lead/Opportunity
- Go to ToDo
- Create / Edit a todo assignee

## Additional Information:

> [!NOTE]
> If the assignee does not have a google calendar automatically `Sync with Google Calendar` checkbox is unchecked


## Screenshot/Screencast


https://github.com/user-attachments/assets/b3088c1c-3f65-4fa8-887c-619e40a4dd54




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Addresses: https://github.com/rtCamp/erp-rtcamp/issues/2402