### PR TITLE
Add Attachment Duplication when migrating Lead to opportunity

### DIFF
--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -51,6 +51,17 @@ def get_opportunity_activities(name):
         activities, calls, _notes, todos, events, attachments = get_lead_activities(
             lead, False
         )
+
+        crm_note_names = frappe.get_all(
+            "CRM Note", filters={"parent": lead, "parenttype": "Lead"}, pluck="name"
+        )
+        filenames_to_exclude = frappe.get_all(
+            "NCRM Attachments",
+            filters={"parenttype": "CRM Note", "parent": ["in", crm_note_names]},
+            pluck="filename",
+        )
+        attachments = [a for a in attachments if a.name not in filenames_to_exclude]
+
         creation_text = "converted the lead to this opportunity"
 
     activities.append(

--- a/next_crm/api/crm_note.py
+++ b/next_crm/api/crm_note.py
@@ -210,7 +210,7 @@ def copy_crm_notes_to_opportunity(lead, opportunity):
         new_parent_note.added_by = note.added_by
         new_parent_note.added_on = note.added_on or now()
 
-        new_parent_note.insert(ignore_permissions=True)
+        new_parent_note.insert()
         attachments = frappe.get_all(
             "NCRM Attachments",
             filters={"parent": note.name, "parenttype": "CRM Note"},
@@ -258,7 +258,7 @@ def copy_crm_notes_to_opportunity(lead, opportunity):
             new_child_note.added_on = child_note.added_on or now()
             new_child_note.custom_parent_note = new_parent_note.name
 
-            new_child_note.insert(ignore_permissions=True)
+            new_child_note.insert()
             child_attachments = frappe.get_all(
                 "NCRM Attachments",
                 filters={"parent": child_note.name, "parenttype": "CRM Note"},


### PR DESCRIPTION
## Description

Previously, when migrating a Lead to an Opportunity, all attachments linked to CRM Notes were also copied as-is. This caused issues during deletion of migrated notes or attachments in the Opportunity, resulting in `Link Validation` errors because the attachments were still linked to the original Lead.

This PR resolves the issue by:
- Adding support for duplicating files: During Lead to Opportunity migration, any files attached to CRM Notes are now duplicated and reattached to the newly created Notes in the Opportunity.
- Filtering out Lead attachments: In `activities.py`, Lead attachments that are linked to CRM Notes are excluded from the Opportunity’s activity to prevent misrepresentation and file redundancy.


## Relevant Technical Choices

- Add `duplicate_file` utility
- Refactor `get_opportunity_activities`

## Testing Instructions

- Go to NCRM
- Create a New Lead
- Try adding normal attachments
- Now create Notes with attachment
- Convert this lead to Opportunity
- All normal attachments along with Note Attachments should be visible in Attachment Tabs
- Also try deleting attachment or any Note , should get deleted without any error

## Additional Information:

> None

## Screenshot/Screencast

[Duplicate File Attachments.webm](https://github.com/user-attachments/assets/7cdb720b-615c-42d1-b7de-c1f2044c8fad)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
