### PR TITLE
fix: Refactor timezone retrieval to use database settings

### DIFF
--- a/next_crm/www/__init__.py
+++ b/next_crm/www/__init__.py
@@ -2,6 +2,7 @@ import datetime
 
 import frappe
 import pytz
+from frappe.utils import get_system_timezone
 
 
 @frappe.whitelist(methods=["POST"], allow_guest=True)
@@ -19,17 +20,14 @@ def get_boot():
             "site_name": frappe.local.site,
             "read_only_mode": frappe.flags.read_only,
             "csrf_token": frappe.sessions.get_csrf_token(),
-            "server_timezone": frappe.db.get_single_value(
-                "System Settings", "time_zone"
-            )
-            or None,
+            "server_timezone": get_system_timezone() or None,
             "server_timezone_offset": get_server_timezone_offset(),
         }
     )
 
 
 def get_server_timezone_offset():
-    timezone_str = frappe.db.get_single_value("System Settings", "time_zone")
+    timezone_str = get_system_timezone()
 
     if not timezone_str:
         return None

--- a/next_crm/www/__init__.py
+++ b/next_crm/www/__init__.py
@@ -1,7 +1,6 @@
 import datetime
 
 import frappe
-import frappe.client
 import pytz
 
 
@@ -20,14 +19,20 @@ def get_boot():
             "site_name": frappe.local.site,
             "read_only_mode": frappe.flags.read_only,
             "csrf_token": frappe.sessions.get_csrf_token(),
-            "server_timezone": frappe.client.get_time_zone().get("time_zone", None),
+            "server_timezone": frappe.db.get_single_value(
+                "System Settings", "time_zone"
+            )
+            or None,
             "server_timezone_offset": get_server_timezone_offset(),
         }
     )
 
 
 def get_server_timezone_offset():
-    timezone_str = frappe.client.get_time_zone().get("time_zone", "UTC")
+    timezone_str = frappe.db.get_single_value("System Settings", "time_zone")
+
+    if not timezone_str:
+        return None
 
     # Get current time in that timezone
     tz = pytz.timezone(timezone_str)


### PR DESCRIPTION
## Description

- Using `frappe.client.get_time_zone().get("time_zone", "UTC")` was returning User's timezone settings instead of server timezone.
- This PR updates code to use `get_system_timezone()` instead to retrieve system wide timezone.

## Relevant Technical Choices

<!-- For Code Reviewers: Please describe your changes. -->

## Testing Instructions

<!-- For someone doing QA: How can the changes in this PR be tested? Please provide step-by-step instructions to test the changes. -->

## Additional Information:

<!-- Include any other context, links, or references that reviewers or QA should be aware of. -->

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--
Example:

Fixes #123
Partially addresses #22
See #834
-->

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2434