### PR TITLE
Add posting date field

### DIFF
--- a/frontend/src/components/Modals/NoteModal.vue
+++ b/frontend/src/components/Modals/NoteModal.vue
@@ -42,12 +42,9 @@
         </div>
         <div>
           <div class="mb-1.5 text-xs text-ink-gray-5">{{ __('Posting Date') }}</div>
-          <TextInput
-            type="datetime-local"
-            size="sm"
-            variant="subtle"
-            :placeholder="__('Posting Date')"
+          <DateTimePicker
             v-model="_note.added_on"
+            :placeholder="__('Posting Date')"
             class="datepicker w-full border-none"
           />
         </div>
@@ -93,11 +90,11 @@
 <script setup>
 import ArrowUpRightIcon from '@/components/Icons/ArrowUpRightIcon.vue'
 import { capture } from '@/telemetry'
-import { TextEditor, call } from 'frappe-ui'
+import { TextEditor, call, DateTimePicker } from 'frappe-ui'
 import { ref, computed, nextTick, watch, h, watchEffect } from 'vue'
 import { useRouter } from 'vue-router'
 import { usersStore } from '@/stores/users'
-import { createToast, toDatetimeLocal } from '@/utils'
+import { createToast } from '@/utils'
 import FilesUploader from '@/components/FilesUploader/FilesUploader.vue'
 import NoteAttachments from '../Activities/NoteAttachments.vue'
 import { isEqual, sortBy } from 'lodash'
@@ -245,7 +242,7 @@ watch(
     nextTick(() => {
       _note.value = { ...props.note }
       if (props.note?.added_on) {
-        _note.value.added_on = toDatetimeLocal(props.note.added_on)
+        _note.value.added_on = props.note.added_on
       }
       const fileNames = (props.note?.attachments || []).map((item) => item.filename)
       attachedFileNames.value = fileNames
@@ -340,11 +337,11 @@ watchEffect(() => {
 
   const title = noteVal.custom_title?.trim() || ''
   const note = noteVal.note || ''
-  const postingDate = toDatetimeLocal(noteVal.added_on) || ''
+  const postingDate = noteVal.added_on || ''
 
   const originalTitle = props.note.custom_title?.trim() || ''
   const originalNote = props.note.note || ''
-  const originalPostingDate = toDatetimeLocal(props.note.added_on) || ''
+  const originalPostingDate = props.note.added_on || ''
 
   const titleChanged = title !== originalTitle
   const noteChanged = note !== originalNote

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -397,3 +397,16 @@ export const sanitizeCurrency = (str) => {
 }
 
 export const replaceMeWithUser = (obj, user) => ({ ...obj, ...Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, v === "@me" ? user : v])) });
+
+/**
+ * Converts a erp-backend datetime string to an HTML datetime-local compatible string.
+ */
+export function toDatetimeLocal(dateStr){
+  if (!dateStr) return ''
+
+  const date = new Date(dateStr)
+  if (isNaN(date.getTime())) return ''
+
+  const tzOffset = date.getTimezoneOffset() * 60000
+  return new Date(date.getTime() - tzOffset).toISOString().slice(0, 16)
+}

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -397,16 +397,3 @@ export const sanitizeCurrency = (str) => {
 }
 
 export const replaceMeWithUser = (obj, user) => ({ ...obj, ...Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, v === "@me" ? user : v])) });
-
-/**
- * Converts a erp-backend datetime string to an HTML datetime-local compatible string.
- */
-export function toDatetimeLocal(dateStr){
-  if (!dateStr) return ''
-
-  const date = new Date(dateStr)
-  if (isNaN(date.getTime())) return ''
-
-  const tzOffset = date.getTimezoneOffset() * 60000
-  return new Date(date.getTime() - tzOffset).toISOString().slice(0, 16)
-}

--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -495,6 +495,7 @@ def get_linked_notes(name):
             "added_on",
             "custom_parent_note",
         ],
+        order_by="added_on desc",
     )
 
     if not notes:
@@ -526,7 +527,7 @@ def get_linked_notes(name):
         parent_note_id = str(note.get("custom_parent_note") or "").strip()
 
         if parent_note_id and parent_note_id in note_map:
-            note_map[parent_note_id]["noteReplies"].insert(0, note_map[note_id])
+            note_map[parent_note_id]["noteReplies"].append(note_map[note_id])
         else:
             root_notes.append(note_map[note_id])
 

--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -527,7 +527,7 @@ def get_linked_notes(name):
         parent_note_id = str(note.get("custom_parent_note") or "").strip()
 
         if parent_note_id and parent_note_id in note_map:
-            note_map[parent_note_id]["noteReplies"].append(note_map[note_id])
+            note_map[parent_note_id]["noteReplies"].insert(0, note_map[note_id])
         else:
             root_notes.append(note_map[note_id])
 

--- a/next_crm/api/crm_note.py
+++ b/next_crm/api/crm_note.py
@@ -11,13 +11,21 @@ from next_crm.ncrm.doctype.crm_notification.crm_notification import notify_user
 
 @frappe.whitelist()
 def create_note(
-    doctype, docname, title=None, note=None, parent_note=None, attachments=None
+    doctype,
+    docname,
+    title=None,
+    note=None,
+    parent_note=None,
+    attachments=None,
+    added_on=None,
 ):
     """
     Create a new CRM Note.
     """
     if not note and not title:
         raise frappe.ValidationError("Either note or title is required.")
+
+    added_on = added_on if added_on else now()
 
     new_note = frappe.get_doc(
         {
@@ -29,7 +37,7 @@ def create_note(
             "parentfield": "notes",
             "owner": frappe.session.user,
             "added_by": frappe.session.user,
-            "added_on": now(),
+            "added_on": added_on,
             "custom_parent_note": parent_note,
         }
     )
@@ -62,6 +70,8 @@ def update_note(doctype, docname, note_name, note=None, attachments=None):
 
     note_doc.custom_title = note.get("custom_title")
     note_doc.note = note.get("note")
+    if note.get("added_on"):
+        note_doc.added_on = note.get("added_on")
 
     if attachments:
         existing_filenames = {row.filename for row in note_doc.custom_note_attachments}


### PR DESCRIPTION
## Description

This PR adds a new `TextInput` field labeled `"Posting Date"`, which updates the `added_on` field of the CRM Note . This PR also updates the order in which `note replies` are displayed.

## Relevant Technical Choices

- Update `crm_note` APIs to include the `added_on` field in the response
- Update `NoteModal` to accommodate and handle the added_on field changes
- Update `get_linked_notes` utility to update note reply order

## Testing Instructions

- Visit NCRM
- Open Lead/Opportunity
- Go to Notes tab
- Try creating or updating posting date of a note

## Additional Information:

> Based on Posting Date the Notes are ordered in `Activities` and in `Note Area`

## Screenshot/Screencast

[Note Posting date.webm](https://github.com/user-attachments/assets/6bd54117-f623-434c-8c56-544afa072005)

<img width="751" height="673" alt="image" src="https://github.com/user-attachments/assets/33496b82-249e-4bbc-9dab-af0583710e57" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Addresses: https://github.com/rtCamp/erp-rtcamp/issues/2435