### PR TITLE
Add posting date field in Note Modal

### DIFF
--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -495,6 +495,7 @@ def get_linked_notes(name):
             "added_on",
             "custom_parent_note",
         ],
+        order_by="added_on desc",
     )
 
     if not notes:

--- a/next_crm/api/crm_note.py
+++ b/next_crm/api/crm_note.py
@@ -11,13 +11,21 @@ from next_crm.ncrm.doctype.crm_notification.crm_notification import notify_user
 
 @frappe.whitelist()
 def create_note(
-    doctype, docname, title=None, note=None, parent_note=None, attachments=None
+    doctype,
+    docname,
+    title=None,
+    note=None,
+    parent_note=None,
+    attachments=None,
+    added_on=None,
 ):
     """
     Create a new CRM Note.
     """
     if not note and not title:
         raise frappe.ValidationError("Either note or title is required.")
+
+    added_on = added_on if added_on else now()
 
     new_note = frappe.get_doc(
         {
@@ -29,7 +37,7 @@ def create_note(
             "parentfield": "notes",
             "owner": frappe.session.user,
             "added_by": frappe.session.user,
-            "added_on": now(),
+            "added_on": added_on,
             "custom_parent_note": parent_note,
         }
     )
@@ -62,6 +70,8 @@ def update_note(doctype, docname, note_name, note=None, attachments=None):
 
     note_doc.custom_title = note.get("custom_title")
     note_doc.note = note.get("note")
+    if note.get("added_on"):
+        note_doc.added_on = note.get("added_on")
 
     if attachments:
         existing_filenames = {row.filename for row in note_doc.custom_note_attachments}


### PR DESCRIPTION
## Description

This PR adds a new `TextInput` field labeled `"Posting Date"`, which updates the `added_on` field of the CRM Note . This PR also updates the order in which `note replies` are displayed.

## Relevant Technical Choices

- Update `crm_note` APIs to include the `added_on` field in the response
- Update `NoteModal` to accommodate and handle the added_on field changes
- Update `get_linked_notes` utility to update note reply order

## Testing Instructions

- Visit NCRM
- Open Lead/Opportunity
- Go to Notes tab
- Try creating or updating posting date of a note

## Additional Information:

> Based on Posting Date the Notes are ordered in `Activities` and in `Note Area`

## Screenshot/Screencast

[Note Posting date.webm](https://github.com/user-attachments/assets/6bd54117-f623-434c-8c56-544afa072005)

<img width="751" height="673" alt="image" src="https://github.com/user-attachments/assets/33496b82-249e-4bbc-9dab-af0583710e57" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Addresses: https://github.com/rtCamp/erp-rtcamp/issues/2435