### PR TITLE
Add settings to hide NCRM pages

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -144,6 +144,7 @@ declare module 'vue' {
     MultiselectInput: typeof import('./src/components/Controls/MultiselectInput.vue')['default']
     MultiValueInput: typeof import('./src/components/Controls/MultiValueInput.vue')['default']
     MuteIcon: typeof import('./src/components/Icons/MuteIcon.vue')['default']
+    NCRMSettings: typeof import('./src/components/Settings/NCRMSettings.vue')['default']
     NestedPopover: typeof import('./src/components/NestedPopover.vue')['default']
     NoteArea: typeof import('./src/components/Activities/NoteArea.vue')['default']
     NoteAttachments: typeof import('./src/components/Activities/NoteAttachments.vue')['default']

--- a/frontend/src/components/Layouts/AppSidebar.vue
+++ b/frontend/src/components/Layouts/AppSidebar.vue
@@ -104,64 +104,67 @@ import { unreadNotificationsCount, notificationsStore } from '@/stores/notificat
 import { FeatherIcon } from 'frappe-ui'
 import { useStorage } from '@vueuse/core'
 import { computed, h } from 'vue'
+import { hiddenPages } from '../../composables/settings'
 
 const { getPinnedViews, getPublicViews } = viewsStore()
 const { toggle: toggleNotificationPanel } = notificationsStore()
 
 const isSidebarCollapsed = useStorage('isSidebarCollapsed', false)
 
-const links = [
-  {
-    label: 'Leads',
-    icon: LeadsIcon,
-    to: 'Leads',
-  },
-  {
-    label: 'Opportunities',
-    icon: OpportunitiesIcon,
-    to: 'Opportunities',
-  },
-  {
-    label: 'Prospects',
-    icon: ProspectsIcon,
-    to: 'Prospects',
-  },
-  {
-    label: 'Contacts',
-    icon: ContactsIcon,
-    to: 'Contacts',
-  },
-  {
-    label: 'Addresses',
-    icon: AddressIcon,
-    to: 'Addresses',
-  },
-  {
-    label: 'Customers',
-    icon: CustomersIcon,
-    to: 'Customers',
-  },
-  {
-    label: 'Reports',
-    icon: FileTextIcon,
-    to: 'Reports',
-  },
-  // {
-  //   label: 'ToDos',
-  //   icon: ToDoIcon,
-  //   to: 'ToDos',
-  // },
-  // {
-  //   label: 'Call Logs',
-  //   icon: PhoneIcon,
-  //   to: 'Call Logs',
-  // },
-  // {
-  //   label: 'Email Templates',
-  //   icon: Email2Icon,
-  //   to: 'Email Templates',
-  // },
-]
+const links = computed(() =>
+  [
+    {
+      label: 'Leads',
+      icon: LeadsIcon,
+      to: 'Leads',
+    },
+    {
+      label: 'Opportunities',
+      icon: OpportunitiesIcon,
+      to: 'Opportunities',
+    },
+    {
+      label: 'Prospects',
+      icon: ProspectsIcon,
+      to: 'Prospects',
+    },
+    {
+      label: 'Contacts',
+      icon: ContactsIcon,
+      to: 'Contacts',
+    },
+    {
+      label: 'Addresses',
+      icon: AddressIcon,
+      to: 'Addresses',
+    },
+    {
+      label: 'Customers',
+      icon: CustomersIcon,
+      to: 'Customers',
+    },
+    {
+      label: 'Reports',
+      icon: FileTextIcon,
+      to: 'Reports',
+    },
+    {
+      label: 'ToDos',
+      icon: ToDoIcon,
+      to: 'ToDos',
+    },
+    {
+      label: 'Call Logs',
+      icon: PhoneIcon,
+      to: 'Call Logs',
+    },
+    {
+      label: 'Email Templates',
+      icon: Email2Icon,
+      to: 'Email Templates',
+    },
+  ].filter((link) => !hiddenPages.value.includes(link.label)),
+)
 
 const allViews = computed(() => {
   let _views = [
@@ -169,7 +172,7 @@ const allViews = computed(() => {
       name: 'All Views',
       hideLabel: true,
       opened: true,
-      views: links,
+      views: links.value,
     },
   ]
   if (getPublicViews().length) {

--- a/frontend/src/components/Settings/NCRMSettings.vue
+++ b/frontend/src/components/Settings/NCRMSettings.vue
@@ -1,0 +1,11 @@
+<template>
+  <SettingsPage
+    doctype="NCRM Settings"
+    :title="__('NCRM Settings')"
+    :successMessage="__('NCRM Settings updated')"
+    class="p-8"
+  />
+</template>
+<script setup>
+import SettingsPage from '@/components/Settings/SettingsPage.vue'
+</script>

--- a/frontend/src/components/Settings/SettingsModal.vue
+++ b/frontend/src/components/Settings/SettingsModal.vue
@@ -19,11 +19,7 @@
                 :icon="i.icon"
                 :label="__(i.label)"
                 class="w-full"
-                :class="
-                  activeTab?.label == i.label
-                    ? 'bg-surface-white shadow-sm'
-                    : 'hover:bg-surface-gray-2'
-                "
+                :class="activeTab?.label == i.label ? 'bg-surface-white shadow-sm' : 'hover:bg-surface-gray-2'"
                 @click="activeTab = i"
               />
             </nav>
@@ -41,9 +37,11 @@ import ContactsIcon from '@/components/Icons/ContactsIcon.vue'
 import WhatsAppIcon from '@/components/Icons/WhatsAppIcon.vue'
 import ERPNextIcon from '@/components/Icons/ERPNextIcon.vue'
 import PhoneIcon from '@/components/Icons/PhoneIcon.vue'
+import SettingsIcon from '@/components/Icons/SettingsIcon.vue'
 import ProfileSettings from '@/components/Settings/ProfileSettings.vue'
 import WhatsAppSettings from '@/components/Settings/WhatsAppSettings.vue'
 import ERPNextSettings from '@/components/Settings/ERPNextSettings.vue'
+import NCRMSettings from '@/components/Settings/NCRMSettings.vue'
 import TwilioSettings from '@/components/Settings/TwilioSettings.vue'
 import SidebarLink from '@/components/SidebarLink.vue'
 import { isWhatsappInstalled } from '@/composables/settings'
@@ -62,6 +60,11 @@ const tabs = computed(() => {
           label: __('Profile'),
           icon: ContactsIcon,
           component: markRaw(ProfileSettings),
+        },
+        {
+          label: __('NCRM'),
+          icon: SettingsIcon,
+          component: markRaw(NCRMSettings),
         },
       ],
     },

--- a/frontend/src/composables/settings.js
+++ b/frontend/src/composables/settings.js
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue'
 
 export const whatsappEnabled = ref(false)
 export const isWhatsappInstalled = ref(false)
+export const hiddenPages = ref([])
 createResource({
   url: 'next_crm.api.whatsapp.is_whatsapp_enabled',
   cache: 'Is Whatsapp Enabled',
@@ -19,6 +20,15 @@ createResource({
     isWhatsappInstalled.value = Boolean(data)
   },
 })
+
+export const hiddenPagesResource = ref(createResource({
+  url: 'next_crm.api.erpnext.get_pages_visibility',
+  cache: 'crm-hidden-pages',
+  auto: true,
+  onSuccess: (data) => {
+    hiddenPages.value = data
+  },
+}))
 
 export const callEnabled = ref(false)
 createResource({

--- a/next_crm/api/erpnext.py
+++ b/next_crm/api/erpnext.py
@@ -168,3 +168,16 @@ def create_customer(customer_data=None):
             frappe.get_traceback(), "Error while creating customer against Opportunity"
         )
         pass
+
+
+@frappe.whitelist()
+def get_pages_visibility():
+    hideable_pages = ["Prospects", "ToDos", "Call Logs", "Email Templates"]
+    hidden_pages = []
+    for page in hideable_pages:
+        page_name = page.lower().replace(" ", "_")
+        hidden = frappe.db.get_single_value("NCRM Settings", page_name)
+        if hidden:
+            hidden_pages.append(page)
+
+    return hidden_pages

--- a/next_crm/ncrm/doctype/ncrm_settings/ncrm_settings.json
+++ b/next_crm/ncrm/doctype/ncrm_settings/ncrm_settings.json
@@ -4,7 +4,15 @@
   "creation": "2024-09-29 13:48:02.715924",
   "doctype": "DocType",
   "engine": "InnoDB",
-  "field_order": ["restore_defaults", "hide_comments_tab"],
+  "field_order": [
+    "restore_defaults",
+    "hide_comments_tab",
+    "hide_pages_section",
+    "prospects",
+    "todos",
+    "call_logs",
+    "email_templates"
+  ],
   "fields": [
     {
       "fieldname": "restore_defaults",
@@ -17,12 +25,41 @@
       "fieldname": "hide_comments_tab",
       "fieldtype": "Check",
       "label": "Hide Comments Tab"
+    },
+    {
+      "fieldname": "hide_pages_section",
+      "fieldtype": "Section Break",
+      "label": "Hide Pages"
+    },
+    {
+      "default": "0",
+      "fieldname": "prospects",
+      "fieldtype": "Check",
+      "label": "Prospects"
+    },
+    {
+      "default": "0",
+      "fieldname": "todos",
+      "fieldtype": "Check",
+      "label": "ToDos"
+    },
+    {
+      "default": "0",
+      "fieldname": "call_logs",
+      "fieldtype": "Check",
+      "label": "Call Logs"
+    },
+    {
+      "default": "0",
+      "fieldname": "email_templates",
+      "fieldtype": "Check",
+      "label": "Email Templates"
     }
   ],
   "index_web_pages_for_search": 1,
   "issingle": 1,
   "links": [],
-  "modified": "2025-05-23 10:51:30.482563",
+  "modified": "2025-08-11 15:47:28.313812",
   "modified_by": "Administrator",
   "module": "NCRM",
   "name": "NCRM Settings",
@@ -39,6 +76,7 @@
       "write": 1
     }
   ],
+  "row_format": "Dynamic",
   "sort_field": "creation",
   "sort_order": "DESC",
   "states": []


### PR DESCRIPTION
## Description

This PR adds settings to NCRM Settings to enable or disable certain pages from sidebar.
The pages can still be opened via URL but won't be visible in sidebar.
This PR also exposes the NCRM settings on frontend for quick changes

## Relevant Technical Choices

Added settings with page names to be able to hide them

## Testing Instructions

- Select a page to hide in NCRM settings
- Refresh NCRM
- The page should no longer be visible

## Screenshot/Screencast

<img width="1156" height="887" alt="image" src="https://github.com/user-attachments/assets/ccae6893-9ce3-4550-bad5-18c4f409b05f" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
