### PR TITLE
Add buton to allow following a document

### DIFF
--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -173,6 +173,20 @@
                     <AttachmentIcon class="h-4 w-4" />
                   </Button>
                 </Tooltip>
+                <div v-if="followStatus == 1">
+                  <Tooltip :text="__('Unfollow Document')">
+                    <Button class="h-7 w-7" @click="updateFollow">
+                      <FeatherIcon name="eye" class="h-4 w-4" />
+                    </Button>
+                  </Tooltip>
+                </div>
+                <div v-else>
+                  <Tooltip :text="__('Follow Document')">
+                    <Button class="h-7 w-7" @click="updateFollow">
+                      <FeatherIcon name="eye-off" class="h-4 w-4" />
+                    </Button>
+                  </Tooltip>
+                </div>
                 <Tooltip :text="__('Delete Lead')">
                   <Button theme="red" class="h-7 w-7" @click="deleteLead">
                     <FeatherIcon name="trash-2" class="h-4 w-4" />
@@ -1122,5 +1136,47 @@ function afterRename(renamed_docname) {
   router.push({ name: props.doctype, params: { leadId: renamed_docname } }).then(() => {
     location.reload();
   });
+}
+
+const followStatus = ref(false)
+
+async function updateFollow(event) {
+  event.stopImmediatePropagation();
+  await call('frappe.desk.form.document_follow.update_follow', {
+    doctype: 'Lead',
+    doc_name: props.leadId,
+    following: !followStatus.value,
+  }).then((res) => {
+    if(res || res === 1 && followStatus.value) {
+      followStatus.value = !followStatus.value
+      createToast({
+        title: __('Follow status updated'),
+        icon: 'check',
+        iconClasses: 'text-ink-green-3',
+      })
+      return
+    }
+    createToast({
+      title: __('Error updating follow status'),
+      icon: 'x',
+      iconClasses: 'text-ink-red-4',
+    })
+
+  })
+  return 0
+}
+
+getFollowStatus()
+function getFollowStatus() {
+  call('next_crm.api.doc.is_document_followed', {
+    doctype: 'Lead',
+    doc_name: props.leadId,
+  }).then((res) => {
+    if(res) {
+      followStatus.value = true
+    } else {
+      followStatus.value = false
+    }
+  })
 }
 </script>

--- a/frontend/src/pages/Opportunity.vue
+++ b/frontend/src/pages/Opportunity.vue
@@ -91,6 +91,20 @@
                 <AttachmentIcon class="size-4" />
               </Button>
             </Tooltip>
+            <div v-if="followStatus">
+              <Tooltip :text="__('Unfollow Document')">
+                <Button class="h-7 w-7" @click="updateFollow">
+                    <FeatherIcon name="eye" class="h-4 w-4" />
+                </Button>
+              </Tooltip>
+            </div>
+            <div v-else>
+              <Tooltip :text="__('Follow Document')">
+                <Button class="h-7 w-7" @click="updateFollow">
+                    <FeatherIcon name="eye-off" class="h-4 w-4" />
+                </Button>
+              </Tooltip>
+            </div>
             <Tooltip :text="__('Delete Opportunity')">
               <Button theme="red" class="h-7 w-7" @click="deleteOpportunity">
                 <FeatherIcon name="trash-2" class="h-4 w-4" />
@@ -1058,6 +1072,47 @@ function getMissingRequiredFields(requiredFieldKeys, data) {
   return requiredFieldKeys.filter(key => {
     const value = data[key]
     return value === undefined || value === null || String(value).trim() === ''
+  })
+}
+
+const followStatus = ref(false)
+
+function updateFollow(event) {
+  event.stopImmediatePropagation();
+  call('frappe.desk.form.document_follow.update_follow', {
+    doctype: 'Opportunity',
+    doc_name: props.opportunityId,
+    following: !followStatus.value,
+  }).then((res) => {
+    if(res || followStatus.value) {
+      followStatus.value = !followStatus.value
+      createToast({
+        title: __('Follow status updated'),
+        icon: 'check',
+        iconClasses: 'text-ink-green-3',
+      })
+      return
+    }
+    createToast({
+      title: __('Error updating follow status'),
+      icon: 'x',
+      iconClasses: 'text-ink-red-4',
+    })
+
+  })
+}
+
+getFollowStatus()
+function getFollowStatus() {
+  call('next_crm.api.doc.is_document_followed', {
+    doctype: 'Opportunity',
+    doc_name: props.opportunityId,
+  }).then((res) => {
+    if(res) {
+      followStatus.value = true
+    } else {
+      followStatus.value = false
+    }
   })
 }
 

--- a/next_crm/api/doc.py
+++ b/next_crm/api/doc.py
@@ -877,3 +877,11 @@ def check_create_access(doctype):
     if frappe.has_permission(doctype, "create"):
         return True
     return False
+
+
+@frappe.whitelist()
+def is_document_followed(doctype, doc_name):
+    return frappe.db.exists(
+        "Document Follow",
+        {"ref_doctype": doctype, "ref_docname": doc_name, "user": frappe.session.user},
+    )


### PR DESCRIPTION
## Description

This adds a button to follow or un-follow a document to Next CRM.

## Relevant Technical Choices

Whitelisted APIs are re-used from document_follow file.

## Testing Instructions

- [ ] Open a lead or opportunity in Next CRM
- [ ] Attempt to follow or unfollow the doc using the eye button
- [ ] The changes should also be visible in ERP

## Screenshot/Screencast


https://github.com/user-attachments/assets/7037bf4f-f21a-47cf-a2c5-5f1843c1bf84




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2459