### PR TITLE
Fix ToDo Validation

### DIFF
--- a/frontend/src/components/Modals/ToDoModal.vue
+++ b/frontend/src/components/Modals/ToDoModal.vue
@@ -281,7 +281,7 @@ async function updateToDo() {
     let current_doc_link = new URL(window.location.href)
     current_doc_link.hash = '#todos'
     if (_todo.value.name) {
-      if (fromTime && toTime) {
+      if (fromTime.value && toTime.value) {
         if (!_todo.value.custom_to_time || !_todo.value.custom_from_time) {
           createToast({
             title: __('Validation error'),
@@ -373,7 +373,7 @@ async function updateToDo() {
         iconClasses: 'text-ink-green-3',
       })
     } else {
-      if (fromTime && toTime) {
+      if (fromTime.value && toTime.value) {
         if (!_todo.value.custom_to_time || !_todo.value.custom_from_time) {
           createToast({
             title: __('Validation error'),


### PR DESCRIPTION
## Description

This PR fixes a ToDo creation error caused when custom `from` and `to` date fields were unset in the default installation. The issue occurred because the validation checked Vue ref objects (fromTime, toTime) instead of their `.value`, which are never empty. The fix updates the check to use `.value `instead.

## Relevant Technical Choices

- Use `.value ` instead of just ref values

## Testing Instructions

- Go to NCRM
- Open any Lead/Opportunity
- Create/update a ToDo

## Additional Information:

> None

## Screenshot/Screencast

[ToDo Validation.webm](https://github.com/user-attachments/assets/114382e5-207f-4cdc-b5df-ae6da1903826)



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/next-crm/issues/281