### PR TITLE
Add Fixed menu and default dates in ToDo Modal

### DIFF
--- a/frontend/src/components/Modals/ToDoModal.vue
+++ b/frontend/src/components/Modals/ToDoModal.vue
@@ -177,7 +177,7 @@ import { TextEditor, Dropdown, Tooltip, call, DatePicker, TextInput } from 'frap
 import { ref, watch, nextTick, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { getMeta } from '@/stores/meta'
-import { createToast } from '@/utils'
+import { createToast, dateFormat } from '@/utils'
 
 const props = defineProps({
   todo: {
@@ -497,6 +497,8 @@ async function render() {
   nextTick(async () => {
     custom_title.value?.el?.focus?.()
     _todo.value = { ...props.todo }
+    _todo.value.custom_from_time = _todo.value.custom_from_time || dateFormat(new Date(), 'YYYY-MM-DDTHH:mm')
+    _todo.value.custom_to_time = _todo.value.custom_to_time || dateFormat(new Date(), 'YYYY-MM-DDTHH:mm')
 
     if (_todo.value._event) {
       _event.value = _todo.value._event


### PR DESCRIPTION
## Description

This PR adds fixed menu to ToDo Modal Description and add default date-time in From and To Time custom fields

## Relevant Technical Choices

- Add fixed_menu prop to TextEditor
- Add `new Date()` to from and to time

## Testing Instructions

- Visit NCRM
- Open Todo tab
- Create/Update a ToDo

## Additional Information:

> None

## Screenshot/Screencast

<img width="637" height="750" alt="image" src="https://github.com/user-attachments/assets/6f8e93c9-88f9-4fd5-b7ae-33913bf64045" />



## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)
