### PR TITLE
hide convert to opportunity for converted lead

### DIFF
--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -33,6 +33,7 @@
         </template>
       </Dropdown>
       <Button
+        v-if="lead?.data?.converted != 1"
         :label="__('Convert to Opportunity')"
         variant="solid"
         @click="showConvertToOpportunityModal = true"


### PR DESCRIPTION
## Description

For Leads that are already converted, don't show the "Convert to Opportunity" button

## Relevant Technical Choices

Added a check based on converted property in lead to hide the convert button

## Testing Instructions

- [ ] Open a lead which is converted to opportunity
- [ ] The lead should not show any convert to opportunity button in topbar

## Screenshot/Screencast

<img width="478" height="137" alt="image" src="https://github.com/user-attachments/assets/100d0c0d-4945-4f9c-98bb-d18b36fb3a9f" />

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

See https://github.com/rtCamp/erp-rtcamp/issues/2483