### PR TITLE
Add linked opportunities tab to Lead

### DIFF
--- a/frontend/components.d.ts
+++ b/frontend/components.d.ts
@@ -157,6 +157,7 @@ declare module 'vue' {
     OpportunitiesIcon: typeof import('./src/components/Icons/OpportunitiesIcon.vue')['default']
     OpportunitiesListView: typeof import('./src/components/ListViews/OpportunitiesListView.vue')['default']
     OpportunityFromSetModal: typeof import('./src/components/Modals/OpportunityFromSetModal.vue')['default']
+    OpportunityListArea: typeof import('./src/components/Activities/OpportunityListArea.vue')['default']
     OpportunityModal: typeof import('./src/components/Modals/OpportunityModal.vue')['default']
     OutboundCallIcon: typeof import('./src/components/Icons/OutboundCallIcon.vue')['default']
     PauseIcon: typeof import('./src/components/Icons/PauseIcon.vue')['default']

--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -88,6 +88,9 @@
           @reload="all_activities.reload()"
         />
       </div>
+      <div v-else-if="title == 'Opportunities'" class="w-full px-3 pb-3 sm:px-5 sm:pb-5 overflow-x-auto">
+        <OpportunityListArea :docname="doc?.data?.name" :doctype="doc?.data?.doctype" :opportunities="activities" />
+      </div>
       <div
         v-else
         v-for="(activity, i) in activities"
@@ -335,6 +338,7 @@ import NoteArea from '@/components/Activities/NoteArea.vue'
 import ToDoArea from '@/components/Activities/ToDoArea.vue'
 import EventArea from '@/components/Activities/EventArea.vue'
 import AttachmentArea from '@/components/Activities/AttachmentArea.vue'
+import OpportunityListArea from '@/components/Activities/OpportunityListArea.vue'
 import UserAvatar from '@/components/UserAvatar.vue'
 import ActivityIcon from '@/components/Icons/ActivityIcon.vue'
 import Email2Icon from '@/components/Icons/Email2Icon.vue'
@@ -410,8 +414,8 @@ const all_activities = createResource({
   params: { name: doc.value.data.name },
   cache: ['activity', doc.value.data.name],
   auto: true,
-  transform: ([versions, calls, notes, todos, events, attachments]) => {
-    return { versions, calls, notes, todos, events, attachments }
+  transform: ([versions, calls, notes, todos, events, attachments, opportunities]) => {
+    return { versions, calls, notes, todos, events, attachments, opportunities }
   },
 })
 
@@ -509,6 +513,9 @@ const activities = computed(() => {
   } else if (title.value == 'Attachments') {
     if (!all_activities.data?.attachments) return []
     return sortByCreation(all_activities.data.attachments)
+  } else if (title.value == 'Opportunities') {
+    if (!all_activities.data?.opportunities) return []
+    return sortByCreation(all_activities.data.opportunities)
   }
 
   _activities.forEach((activity) => {
@@ -576,6 +583,8 @@ const emptyText = computed(() => {
     text = 'No Attachments'
   } else if (title.value == 'WhatsApp') {
     text = 'No WhatsApp Messages'
+  } else if (title.value == 'Opportunities') {
+    text = 'No Opportunities'
   }
   return text
 })
@@ -598,6 +607,8 @@ const emptyTextIcon = computed(() => {
     icon = AttachmentIcon
   } else if (title.value == 'WhatsApp') {
     icon = WhatsAppIcon
+  } else if (title.value == 'Opportunities') {
+    icon = OpportunitiesIcon
   }
   return h(icon, { class: 'text-ink-gray-4' })
 })
@@ -657,6 +668,7 @@ watch(
       Events: value?.events?.length || 0,
       Notes: value?.notes?.length || 0,
       Attachments: value?.attachments?.length || 0,
+      Opportunities: value?.opportunities?.length || 0,
     }
 
     for (const [name, count] of Object.entries(tabCounts)) {

--- a/frontend/src/components/Activities/OpportunityListArea.vue
+++ b/frontend/src/components/Activities/OpportunityListArea.vue
@@ -1,0 +1,64 @@
+<template>
+  <OpportunitiesListView
+    v-if="rows.length"
+    :rows="rows"
+    :columns="columns"
+    :options="{ selectable: false, showTooltip: false }"
+  />
+</template>
+<script setup>
+import OpportunitiesListView from '@/components/ListViews/OpportunitiesListView.vue'
+import { computed } from 'vue'
+import { usersStore } from '@/stores/users.js'
+import { statusesStore } from '@/stores/statuses'
+
+const { getUser } = usersStore()
+const { getDealStatus } = statusesStore()
+
+const props = defineProps({
+  opportunities: Array,
+  docname: String,
+  doctype: String,
+})
+
+const rows = computed(() => {
+  if (!props.opportunities || props.opportunities == []) return []
+
+  return props.opportunities.map((row) => getOpportunityRowObject(row))
+})
+
+const columns = computed(() => opportunityColumns)
+
+function getOpportunityRowObject(opportunity) {
+  return {
+    name: opportunity.name,
+    title: opportunity.title,
+    status: {
+      label: opportunity.status,
+      color: getDealStatus(opportunity.status)?.iconColorClass,
+    },
+    opportunity_owner: {
+      label: opportunity.opportunity_owner && getUser(opportunity.opportunity_owner).full_name,
+      ...(opportunity.opportunity_owner && getUser(opportunity.opportunity_owner)),
+    },
+  }
+}
+
+const opportunityColumns = [
+  {
+    label: __('Title'),
+    key: 'title',
+    width: '20rem',
+  },
+  {
+    label: __('Status'),
+    key: 'status',
+    width: '8rem',
+  },
+  {
+    label: __('Opportunity owner'),
+    key: 'opportunity_owner',
+    width: '10rem',
+  },
+]
+</script>

--- a/frontend/src/pages/Lead.vue
+++ b/frontend/src/pages/Lead.vue
@@ -621,6 +621,7 @@ import AttachmentIcon from '@/components/Icons/AttachmentIcon.vue'
 import ArrowUpRightIcon from '@/components/Icons/ArrowUpRightIcon.vue'
 import AddressIcon from '@/components/Icons/AddressIcon.vue'
 import SuccessIcon from '@/components/Icons/SuccessIcon.vue'
+import OpportunitiesIcon from '@/components/Icons/OpportunitiesIcon.vue'
 import AssignmentModal from '@/components/Modals/AssignmentModal.vue'
 import LoadingIndicator from '@/components/Icons/LoadingIndicator.vue'
 import LayoutHeader from '@/components/LayoutHeader.vue'
@@ -1011,6 +1012,12 @@ const tabs = computed(() => {
       name: 'Attachments',
       label: __('Attachments'),
       icon: AttachmentIcon,
+      count: ref(0)
+    },
+    {
+      name: 'Opportunities',
+      label: __('Opportunities'),
+      icon: OpportunitiesIcon,
       count: ref(0)
     },
     {

--- a/next_crm/api/activities.py
+++ b/next_crm/api/activities.py
@@ -48,8 +48,8 @@ def get_opportunity_activities(name):
 
     if opportunity_from == "Lead":
         lead = doc[3]
-        activities, calls, _notes, todos, events, attachments = get_lead_activities(
-            lead, False, True
+        activities, calls, _notes, todos, events, attachments, _opportunities = (
+            get_lead_activities(lead, False, True)
         )
 
         creation_text = "converted the lead to this opportunity"
@@ -217,7 +217,7 @@ def get_opportunity_activities(name):
     activities = handle_multiple_versions(activities)
     notes.sort(key=lambda x: x["added_on"], reverse=True)
 
-    return activities, calls, notes, todos, events, attachments
+    return activities, calls, notes, todos, events, attachments, []
 
 
 def get_lead_activities(name, get_events=True, exclude_crm_note_attachments=False):
@@ -387,6 +387,7 @@ def get_lead_activities(name, get_events=True, exclude_crm_note_attachments=Fals
     todos = get_linked_todos(name)
     events = get_linked_events(name)
     attachments = get_attachments("Lead", name)
+    opportunities = get_linked_opportunities("Lead", name)
 
     if exclude_crm_note_attachments:
         filenames_to_exclude = linked_notes["attached_file_names"]
@@ -396,7 +397,7 @@ def get_lead_activities(name, get_events=True, exclude_crm_note_attachments=Fals
     activities = handle_multiple_versions(activities)
     notes.sort(key=lambda x: x["added_on"], reverse=True)
 
-    return activities, calls, notes, todos, events, attachments
+    return activities, calls, notes, todos, events, attachments, opportunities
 
 
 def get_attachments(doctype, name):
@@ -621,6 +622,23 @@ def get_linked_events(name):
         )
 
     return events or []
+
+
+def get_linked_opportunities(doctype, name):
+    opportunities = frappe.get_all(
+        "Opportunity",
+        filters={"opportunity_from": doctype, "party_name": name},
+        fields=[
+            "name",
+            "title",
+            "status",
+            "opportunity_owner",
+            "modified",
+            "creation",
+        ],
+    )
+
+    return opportunities
 
 
 def parse_attachment_log(html, type):


### PR DESCRIPTION
## Description

This PR adds a tab to the Lead page to show all linked opportunities with that Lead

## Relevant Technical Choices

- Re-used the Opportunities list view used in other pages
- Created new activity area for opportunities
- Added function in activities to fetch liked opportunities

## Testing Instructions

- [x] Open a lead which is converted to opportunity
- [x] The lead should show all linked opportunities (ideally should be one)

## Screenshot/Screencast

<!-- Add visual aids to demonstrate the changes made in this PR, if applicable. -->
<img width="1867" height="1040" alt="image" src="https://github.com/user-attachments/assets/1527470d-7a70-4576-9791-b2ce3bebc9ec" />

<img width="1867" height="1040" alt="image" src="https://github.com/user-attachments/assets/9f55d869-243d-4f4f-92e7-18a63defaf5a" />


## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

Fixes https://github.com/rtCamp/erp-rtcamp/issues/2483