### PR TITLE
Update ToDo permissions to show all sales teams ToDo

### DIFF
--- a/next_crm/api/doc.py
+++ b/next_crm/api/doc.py
@@ -294,7 +294,12 @@ def get_data(
             filters["disabled"] = 0
 
     if doctype == "ToDo":
-        filters["allocated_to"] = ["=", frappe.session.user]
+        users = frappe.get_all(
+            "Employee",
+            filters={"department": ["like", "sales%"], "user_id": ["is", "set"]},
+            pluck="user_id",
+        )
+        filters["allocated_to"] = ["in", users]
         filters["reference_type"] = ["in", ["Lead", "Opportunity", "Customer", "Task"]]
 
     is_default = True


### PR DESCRIPTION
## Description

This PR updates ToDo permissions to show all ToDos allocated to the sales team.

## Relevant Technical Choices

Update `allocated_to` in ToDo API to have a like filter on `department`

## Testing Instructions

- A sales team member should be able to view ToDo of all other sales team members

## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)


Fixes https://github.com/rtCamp/erp-rtcamp/issues/2498