### PR TITLE
feat: Enhance Activity Stream Attachment Links

### DIFF
--- a/frontend/src/components/Activities/Activities.vue
+++ b/frontend/src/components/Activities/Activities.vue
@@ -169,9 +169,9 @@
                 class="text-blue-600 hover:underline"
                 :style="isURL(activity.data.file_url) ? 'word-break: break-all; white-space: normal;' : ''"
               >
-                <span>{{ activity.data.file_name }}</span>
+                <span>{{ activity.data.file_url }}</span>
               </a>
-              <span v-else>{{ activity.data.file_name }}</span>
+              <span v-else>{{ activity.data.file_url }}</span>
               <FeatherIcon v-if="activity.data.is_private" name="lock" class="size-3" />
             </div>
             <div class="ml-auto whitespace-nowrap">


### PR DESCRIPTION
[Issue 1](https://github.com/rtCamp/erp-rtcamp/issues/2526)
[Issue 2](https://github.com/rtCamp/erp-rtcamp/issues/2525)

**This PR fixes following issues by implementing client-side logic:**

- Prevent Truncation: Ensure the full URL is visible by overriding the aggressive .truncate CSS class when the content is identified as a URL.
- Improve UX: Render the URL as a proper, clickable link with standard link styling (color and underline).

**Relevant Technical Choices:**
- Frontend Logic: Implemented an isURL utility function using a Regular Expression within Activities.vue to reliably identify URLs.
- Conditional Rendering: Used v-if directive to conditionally render the content inside an <a> tag, applying dynamic class and style bindings (:class and :style) to remove truncation (white-space: normal) only for detected URLs.
- Targeted Fixes: Applied this logic to the attachment_log section and the relevant changed version history fields (old_value and value).

**Testing Instructions**

1. Checkout this branch and run bench build.
2. Open any document within the Next CRM module (e.g., Lead or Opportunity).
3. Go to the Attachments tab and click New → Link.
4. Paste a very long URL (e.g., one over 50 characters) and save it.
5. Navigate back to the Activity tab.
6. Verify: The newly added link should be visible in its entirety, display in blue text, and have an underline (functioning as a link).
7. Verify (Version History): Change a URL-type field (e.g., 'Website') on the document. The 'Changed' entry should also show the old and new URLs as clickable, non-truncated links.

<img width="949" height="384" alt="Screenshot 2025-12-16 at 1 43 26 PM" src="https://github.com/user-attachments/assets/ff26ea32-3303-440c-bb77-45990e285083" />




## Checklist

<!-- Check these after creating PR, use NA if something is not applicable -->

- [x] I have carefully reviewed the code before submitting it for review.
- [ ] This code is adequately covered by unit tests to validate its functionality.
- [x] I have conducted thorough testing to ensure it functions as intended.
- [ ] A member of the QA team has reviewed and tested this PR (To be checked by QA or code reviewer)

<!--