### PR TITLE
chore(ci): restrict GitHub Actions token permissions to resolve code-scanning alert

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,4 +1,6 @@
 name: Bench Build Test
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 
 name: CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -1,4 +1,6 @@
 name: Generate Semantic Release
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
## **Description**

This PR hardens our GitHub Actions workflows by explicitly restricting the `GITHUB_TOKEN` permissions to **read-only repository contents**.

The change resolves the GitHub Code Scanning alerts reported in:

* [https://github.com/rtCamp/next-crm/security/code-scanning/1](https://github.com/rtCamp/next-crm/security/code-scanning/1)
* [https://github.com/rtCamp/next-crm/security/code-scanning/2](https://github.com/rtCamp/next-crm/security/code-scanning/2)
* [https://github.com/rtCamp/next-crm/security/code-scanning/3](https://github.com/rtCamp/next-crm/security/code-scanning/3)

By defining minimal permissions, we follow the **principle of least privilege** and reduce the risk of unintended repository modifications during CI runs.

---

## **Relevant Technical Choices**

* Added the following permission block to the workflows:

  ```yaml
  permissions:
    contents: read
  ```
* Updated workflows:

  * `build_test.yml`
  * `ci.yml`
  * `on_release.yml`
* This aligns with GitHub security best practices and satisfies CodeQL recommendations. 
* referenced [next_pms](https://github.com/rtCamp/next-pms/blob/main/.github/workflows/build-test.yml#L2)

---